### PR TITLE
Add chassis orientation support and UI controls

### DIFF
--- a/foundry_state.py
+++ b/foundry_state.py
@@ -32,7 +32,7 @@ class DriveInfo:
     on_time: Optional[int]
     temp: Optional[int]
     hash: int
-    
+
     def __post_init__(self):
         if not hasattr(self, 'hash'):
             self.hash = xxhash.xxh3_64(self.serial_num).intdigest()
@@ -40,10 +40,10 @@ class DriveInfo:
 
 class Drive:
     """Represents a storage drive with S.M.A.R.T. data."""
-    
-    def __init__(self, protocol: str, model: str, serial_num: str, firmware_ver: str, 
-                 capacity: Optional[Union[int, str]], rotate_rate: Optional[int], 
-                 power_cycle: Optional[int], on_time: Optional[int], temp: Optional[int], 
+
+    def __init__(self, protocol: str, model: str, serial_num: str, firmware_ver: str,
+                 capacity: Optional[Union[int, str]], rotate_rate: Optional[int],
+                 power_cycle: Optional[int], on_time: Optional[int], temp: Optional[int],
                  attribute_list: Optional[Any]):
         self.protocol = protocol
         self.model = model
@@ -66,12 +66,12 @@ class Drive:
                 rows = []
                 for attr in self.attribute_list:
                     rows.append({
-                        'ID': attr.get("id", "Unknown"), 
-                        "Name": attr.get("name", "Unknown"), 
+                        'ID': attr.get("id", "Unknown"),
+                        "Name": attr.get("name", "Unknown"),
                         "Value": attr.get("raw", {}).get("string", "Unknown")
                     })
                 return rows
-            
+
             elif self.protocol == 'NVMe':
                 if not self.attribute_list:
                     return []
@@ -81,10 +81,10 @@ class Drive:
                         value = ", ".join(str(e) for e in value)
                     rows.append({"Name": key, "Value": str(value)})
                 return rows
-            
+
             else:
                 return [{"Name": f"Protocol {self.protocol} not yet implemented", "Value": "N/A"}]
-                
+
         except Exception as e:
             logger.error(f"Error getting attribute list for drive {self.serial_num}: {e}")
             return [{"Name": "Error", "Value": "Failed to parse attributes"}]
@@ -113,19 +113,19 @@ class SmartCtlInterface:
         try:
             cmd = f"smartctl {args}"
             result = subprocess.run(
-                cmd, 
-                shell=True, 
-                capture_output=True, 
-                text=True, 
+                cmd,
+                shell=True,
+                capture_output=True,
+                text=True,
                 timeout=timeout
             )
             if result.returncode == 127:
                 raise FoundryStateError("smartctl command not found. Please install smartmontools.")
             if result.returncode < 0:  # Negative return codes indicate serious errors
                 raise FoundryStateError(f"smartctl command failed: {result.stderr}")
-            
+
             return result.stdout
-            
+
         except subprocess.TimeoutExpired:
             logger.error(f"smartctl command timed out: {cmd}")
             raise FoundryStateError(f"Command timed out: {cmd}")
@@ -152,11 +152,11 @@ class SmartCtlInterface:
         try:
             device_path = device_id.split(' ')[0]
             json_output = cls.execute_command(f"--xall --json --device auto {device_path}")
-            
+
             if not json_output.strip():
                 logger.warning(f"No output from smartctl for device {device_path}")
                 return None
-                
+
             data = json.loads(json_output)
             drive = cls._parse_smart_data(data)
 
@@ -165,7 +165,7 @@ class SmartCtlInterface:
                     cls._save_raw_data(drive.model, json_output)
 
             return drive
-            
+
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON for device {device_id}: {e}")
             return None
@@ -179,7 +179,7 @@ class SmartCtlInterface:
         try:
             device_info = data.get('device', {})
             protocol = device_info.get('protocol')
-            
+
             if not protocol:
                 logger.warning("No protocol found in S.M.A.R.T. data")
                 return None
@@ -188,7 +188,7 @@ class SmartCtlInterface:
             model = data.get('model_name') or data.get('scsi_model_name')
             serial_num = data.get('serial_number')
             firmware_ver = data.get('firmware_version')
-            
+
             if not serial_num:
                 logger.warning("No serial number found, skipping drive")
                 return None
@@ -216,7 +216,7 @@ class SmartCtlInterface:
                 power_cycle = data.get('power_cycle_count')
                 ata_smart = data.get('ata_smart_attributes', {})
                 attribute_list = ata_smart.get('table') if ata_smart else None
-                
+
             elif protocol == 'SCSI':
                 scsi_counter = data.get('scsi_start_stop_cycle_counter', {})
                 power_cycle = scsi_counter.get('accumulated_start_stop_cycles') if scsi_counter else None
@@ -225,11 +225,11 @@ class SmartCtlInterface:
                     temperature = report.get('temperature_1', {}) if report else None
                     temp = temperature.get('current') if temperature else None
                 attribute_list = []
-                
+
             elif protocol == 'NVMe':
                 power_cycle = data.get('power_cycle_count')
                 attribute_list = data.get('nvme_smart_health_information_log')
-                
+
             else:
                 logger.warning(f"Unsupported protocol: {protocol}")
                 power_cycle = None
@@ -247,7 +247,7 @@ class SmartCtlInterface:
                 temp=temp,
                 attribute_list=attribute_list
             )
-            
+
         except Exception as e:
             logger.error(f"Error parsing S.M.A.R.T. data: {e}")
             return None
@@ -258,17 +258,17 @@ class SmartCtlInterface:
         try:
             safe_model = "".join(c for c in model if c.isalnum() or c in (' ', '-', '_')).rstrip()
             filename = f"{safe_model}_smartctl.json"
-            
+
             with open(filename, "w", encoding='utf-8') as file:
                 file.write(json_output)
-                
+
         except Exception as e:
             logger.error(f"Failed to save raw data for {model}: {e}")
 
 
 class DriveManager:
     """Manages drive detection and caching."""
-    
+
     def __init__(self, debug,cache_duration: int = 300):  # 5 minutes cache
         self._drive_cache: Dict[int, Drive] = {}
         self._last_scan_time: float = 0
@@ -281,9 +281,9 @@ class DriveManager:
     def get_drives(self, force_refresh: bool = False) -> Dict[int, Drive]:
         """Get all drives with caching."""
         current_time = time.time()
-        
-        if (not force_refresh and 
-            self._drive_cache and 
+
+        if (not force_refresh and
+            self._drive_cache and
             (current_time - self._last_scan_time) < self._cache_duration):
             logger.info("Using cached drive data")
             return self._drive_cache.copy()
@@ -291,14 +291,14 @@ class DriveManager:
         logger.info("Scanning for drives...")
         self._drive_cache = self._scan_drives()
         self._last_scan_time = current_time
-        
+
         return self._drive_cache.copy()
 
     def _scan_drives(self) -> Dict[int, Drive]:
         """Scan for all drives and return dictionary."""
         drives = {}
         drive_ids = SmartCtlInterface.get_drive_ids()
-        
+
         for device_id in drive_ids:
             try:
                 drive = SmartCtlInterface.get_smart_data(device_id, self._debug)
@@ -307,7 +307,7 @@ class DriveManager:
                     logger.info(f"Added drive: {drive.model} ({drive.serial_num})")
                 else:
                     logger.warning(f"Failed to get data for device: {device_id}")
-                    
+
             except Exception as e:
                 logger.error(f"Error processing device {device_id}: {e}")
                 continue
@@ -326,19 +326,19 @@ class DriveManager:
     def refresh_drives_dict(self, existing_drives: Dict[int, Drive]) -> None:
         """
         Refresh an existing drives dictionary in-place, preserving object references where possible.
-        
+
         Args:
             existing_drives: Dictionary to update with current drive information
         """
         try:
             # Get fresh drive data
             fresh_drives = self.get_drives(force_refresh=True)
-            
+
             # Track changes for logging
             updated_count = 0
             added_count = 0
             removed_hashes = []
-            
+
             # Update existing drives in-place and add new ones
             for drive_hash, fresh_drive in fresh_drives.items():
                 if drive_hash in existing_drives:
@@ -350,60 +350,60 @@ class DriveManager:
                     # Add new drive
                     existing_drives[drive_hash] = fresh_drive
                     added_count += 1
-            
+
             # Remove drives that are no longer present
             for drive_hash in list(existing_drives.keys()):
                 if drive_hash not in fresh_drives:
                     removed_hashes.append(drive_hash)
                     del existing_drives[drive_hash]
-            
+
             logger.info(f"Refreshed drives dictionary: {updated_count} updated, "
                        f"{added_count} added, {len(removed_hashes)} removed")
-            
+
         except Exception as e:
             logger.error(f"Error refreshing drives dictionary: {e}")
             raise
 
     def _update_drive_inplace(self, existing_drive: Drive, fresh_drive: Drive) -> bool:
         """Update an existing Drive object with fresh data in-place.
-        
+
         Args:
             existing_drive: The existing Drive object to update
             fresh_drive: The fresh Drive object with new data
-            
+
         Returns:
             bool: True if any changes were made, False otherwise
         """
         changed = False
-        
+
         # List of attributes that might change over time
         updatable_attrs = ['on_time', 'temp', 'attribute_list']
-        
+
         for attr in updatable_attrs:
             fresh_value = getattr(fresh_drive, attr)
             existing_value = getattr(existing_drive, attr)
-            
+
             if fresh_value != existing_value:
                 setattr(existing_drive, attr, fresh_value)
                 changed = True
-        
+
         return changed
 
 
 class Backplane:
     """Represents a backplane that holds drives."""
-    
+
     # Class-level configuration for backplane types
     BACKPLANE_CONFIGS = {
         "STD4HDD": {"slots": 4, "type": "HDD"},
         "STD12SSD": {"slots": 12, "type": "SSD"},
         "SML2+2": {"slots": 4, "type": "Mixed"}
     }
-    
+
     def __init__(self, product: str):
         if product not in self.BACKPLANE_CONFIGS:
             raise ValueError(f"Unknown backplane product: {product}")
-            
+
         self.product = product
         self.config = self.BACKPLANE_CONFIGS[product]
         self.drives_hashes = [None] * self.config["slots"]
@@ -439,10 +439,10 @@ class Backplane:
 
 class Chassis:
     """Manages chassis layout and backplane configuration."""
-    
+
     DEFAULT_CONFIG_FILE = "config/layout_config.json"
     MAX_BACKPLANES = 12
-    
+
     def __init__(self, config_file: Optional[str] = None):
         self.config_file = config_file or self.DEFAULT_CONFIG_FILE
         self.product: Optional[str] = None
@@ -450,6 +450,7 @@ class Chassis:
         self.show_model = True
         self.show_sn = True
         self.hide_multi_curve_dialog = False  # User preference for multi-curve dialog
+        self.chassis_orientation = "normal"  # "normal" or "inverted"
 
         if config_file:
             self._load_config()
@@ -466,18 +467,19 @@ class Chassis:
 
             with open(config_path, "r", encoding='utf-8') as file:
                 config:dict = json.load(file)
-                
+
             self.product = config.get("product")
             backplanes_data = config.get("backplanes", [])
             options = config.get("options", {})
             self.show_model = options.get("show_model", True)
             self.show_sn = options.get("show_sn", True)
             self.hide_multi_curve_dialog = options.get("hide_multi_curve_dialog", False)
+            self.chassis_orientation = options.get("chassis_orientation", "normal")
 
             # Ensure we have the right number of backplane slots
             while len(backplanes_data) < self.MAX_BACKPLANES:
                 backplanes_data.append(None)
-                
+
             self.backplanes = []
             for bp_data in backplanes_data[:self.MAX_BACKPLANES]:
                 if bp_data is None:
@@ -490,9 +492,9 @@ class Chassis:
                     except Exception as e:
                         logger.error(f"Error loading backplane: {e}")
                         self.backplanes.append(None)
-                        
+
             logger.info(f"Loaded chassis config: {self.product}")
-            
+
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in config file: {e}")
             self._reset_to_defaults()
@@ -527,17 +529,28 @@ class Chassis:
     def get_sn_display(self):
         """Return model display option."""
         return self.show_sn
-    
+
+    def get_chassis_orientation(self) -> str:
+        """Get chassis orientation setting."""
+        return self.chassis_orientation
+
+    def set_chassis_orientation(self, orientation: str) -> None:
+        """Set chassis orientation setting."""
+        if orientation not in ["normal", "inverted"]:
+            raise ValueError(f"Invalid orientation: {orientation}. Must be 'normal' or 'inverted'")
+        self.chassis_orientation = orientation
+        self.save_config()
+
     def get_product(self) -> Optional[str]:
         """Get chassis product type."""
         return self.product
-    
+
     def insert_backplane(self, card, product: str) -> Backplane:
         """Insert backplane at specified card."""
         card_index = card.index if hasattr(card, 'index') else card
         if not (0 <= card_index < self.MAX_BACKPLANES):
             raise IndexError(f"Invalid backplane index: {card_index}")
-            
+
         backplane = Backplane(product)
         self.backplanes[card_index] = backplane
         self.save_config()
@@ -548,7 +561,7 @@ class Chassis:
         card_index = card.index if hasattr(card, 'index') else card
         if not (0 <= card_index < self.MAX_BACKPLANES):
             raise IndexError(f"Invalid backplane index: {card_index}")
-            
+
         self.backplanes[card_index] = None
         self.save_config()
 
@@ -565,11 +578,11 @@ class Chassis:
         card_index = card.index if hasattr(card, 'index') else card
         if not (0 <= card_index < self.MAX_BACKPLANES):
             raise IndexError(f"Invalid card index: {card_index}")
-            
+
         backplane = self.backplanes[card_index]
         if backplane is None:
             raise ValueError(f"No backplane at index {card_index}")
-            
+
         # Parse drive serial number from selection string
         try:
             serial_num = drive_selection.split()[-1][1:-1]  # Extract from format "Model (SN123)"
@@ -585,17 +598,22 @@ class Chassis:
         card_index = card.index if hasattr(card, 'index') else card
         if not (0 <= card_index < self.MAX_BACKPLANES):
             raise IndexError(f"Invalid card index: {card_index}")
-            
+
         backplane = self.backplanes[card_index]
         if backplane is None:
             raise ValueError(f"No backplane at index {card_index}")
-            
+
         backplane.remove_drive(drive_hash)
         self.save_config()
 
     def reset_chassis(self) -> None:
         """Reset chassis to empty state."""
         self.product = None
+        self.backplanes = [None] * self.MAX_BACKPLANES
+        self.save_config()
+
+    def clear_all_backplanes(self) -> None:
+        """Clear all backplanes while keeping chassis product and other settings."""
         self.backplanes = [None] * self.MAX_BACKPLANES
         self.save_config()
 
@@ -606,21 +624,22 @@ class Chassis:
                 "product": self.product,
                 "backplanes": [bp.to_json() if bp is not None else None for bp in self.backplanes],
                 "options": {
-                    "show_model": self.show_model, 
+                    "show_model": self.show_model,
                     "show_sn": self.show_sn,
-                    "hide_multi_curve_dialog": self.hide_multi_curve_dialog
+                    "hide_multi_curve_dialog": self.hide_multi_curve_dialog,
+                    "chassis_orientation": self.chassis_orientation
                 }
             }
-            
+
             # Ensure config directory exists
             config_path = Path(self.config_file)
             config_path.parent.mkdir(parents=True, exist_ok=True)
-            
+
             with open(self.config_file, "w", encoding='utf-8') as file:
                 json.dump(config_data, file, indent=4)
-                
+
             logger.info("Configuration saved successfully")
-            
+
         except Exception as e:
             logger.error(f"Error saving configuration: {e}")
             raise FoundryStateError(f"Failed to save configuration: {e}")
@@ -629,7 +648,7 @@ class Chassis:
         """Get chassis statistics."""
         total_backplanes = sum(1 for bp in self.backplanes if bp is not None)
         total_drives = sum(bp.get_drive_count() for bp in self.backplanes if bp is not None)
-        
+
         return {
             "product": self.product,
             "total_backplanes": total_backplanes,

--- a/pages/overview_page.py
+++ b/pages/overview_page.py
@@ -9,19 +9,19 @@ import globals
 
 class DriveButton(ui.button):
     """Custom button class used to select and display drives.
-    
+
     When a drive button is clicked, it gives the option to assign a drive if there is none.
-    Once assigned, clicking on the drive will display basic data on the right drawer. 
+    Once assigned, clicking on the drive will display basic data on the right drawer.
     Clicking VIEW ALL will pop up a window with raw smartctl data values if there are any.
     Each button is a child of a card element that represents a backplane.
     """
-    
+
     def __init__(self, card, button_index, drive_hash) -> None:
         super().__init__()
         self.selected = False
         self.card = card
         self.button_index = button_index
-        
+
         with self:
             with ui.row().classes('items-center gap-2 w-full overflow-hidden') as self.row_element:
                 if drive_hash is None or drive_hash not in globals.drivesList:
@@ -59,7 +59,7 @@ class DriveButton(ui.button):
         self.temp_label.set_visibility(True)
         self.temp_label.style('color: white')
         self.temp_label.bind_text_from(self.assigned_drive, 'temp', lambda temp: f"{temp}°C")
-            
+
     async def clear_drive(self):
         """Remove the assigned drive from this button."""
         globals.layoutState.remove_drive(self.card, self.assigned_drive.hash)
@@ -74,7 +74,7 @@ class DriveButton(ui.button):
 
 class HDDButton(DriveButton):
     """Button styled for HDD drives."""
-    
+
     def __init__(self, card, button_index, drive_hash) -> None:
         super().__init__(card, button_index, drive_hash)
         self.props('flat color="white" size="11px"').classes(
@@ -96,7 +96,7 @@ class HDDButton(DriveButton):
 
 class SmlSSDButton(DriveButton):
     """Button styled for small SSD drives."""
-    
+
     def __init__(self, card, button_index, drive_hash) -> None:
         super().__init__(card, button_index, drive_hash)
         self.props('flat color="white" align="left" size="11px"').classes(
@@ -114,11 +114,11 @@ class SmlSSDButton(DriveButton):
             if globals.layoutState.show_model == False and self.assigned_drive != None:
                 self.model_label.set_visibility(False)
             if globals.layoutState.show_sn == False or self.assigned_drive is None:
-                self.sn_label.set_visibility(False) 
+                self.sn_label.set_visibility(False)
 
 class StdSSDButton(DriveButton):
     """Button styled for standard SSD drives."""
-    
+
     def __init__(self, card, button_index, drive_hash) -> None:
         super().__init__(card, button_index, drive_hash)
         self.props('flat color="white" size="11px"').classes(
@@ -136,11 +136,11 @@ class StdSSDButton(DriveButton):
             if globals.layoutState.show_model == False and self.assigned_drive != None:
                 self.model_label.set_visibility(False)
             if globals.layoutState.show_sn == False or self.assigned_drive is None:
-                self.sn_label.set_visibility(False) 
+                self.sn_label.set_visibility(False)
 
 class FansRowButton(ui.button):
     """Button for fan row controls."""
-    
+
     def __init__(self) -> None:
         super().__init__()
         self.selected = False
@@ -166,7 +166,7 @@ class FanRowButtons(ui.element):
 
 class RPMCard(ui.element):
     """Button for fan row controls."""
-    
+
     def __init__(self, index) -> None:
         super().__init__('div')
 
@@ -184,7 +184,7 @@ class RPMCard(ui.element):
 
 class WattageCard(ui.element):
     """Card to show wattage info from powerboard."""
-    
+
     def __init__(self, index) -> None:
         super().__init__('div')
         with self.classes('col-span-3 px-1 p-1 flex content-center justify-center items-center w-full border-solid border-white rounded-md border-2 bg-neutral-900'):
@@ -208,7 +208,7 @@ class WattageCard(ui.element):
 
 class StdPlaceHolderCard(ui.element):
     """Standard size card representing standard backplanes."""
-    
+
     def __init__(self, index, backplane: Backplane) -> None:
         super().__init__('div')
         self.index = index
@@ -231,7 +231,7 @@ class StdPlaceHolderCard(ui.element):
 
 class SmlPlaceHolderCard(ui.element):
     """Small size card representing small backplanes."""
-    
+
     def __init__(self, index, backplane) -> None:
         super().__init__('div')
         self.index = index
@@ -273,10 +273,10 @@ class FadingDropdown(ui.element):
         """
         # 2. We call the parent constructor, defining this component AS a 'div'.
         super().__init__('div')
-        
+
         # 'self' is now the container div. We apply the initial classes to it.
         self.classes(container_classes).style(f'width: 87%;')
-        
+
         self.is_visible = False
         self.hide_timer: Optional[ui.timer] = None
 
@@ -285,7 +285,7 @@ class FadingDropdown(ui.element):
             # 4. We manually construct the button and menu for full control.
             self.button = ui.button(text, color=button_color, icon=icon).props('outline color="white"')
             self.button.classes('opacity-0 transition-opacity duration-300').style('visibility: hidden;')
-            
+
             with self.button:
                 self.menu = ui.menu().props('fit')
 
@@ -325,7 +325,7 @@ class FadingDropdown(ui.element):
 
 class SystemOverview:
     """Main class to handle the system overview page functionality."""
-    
+
     def __init__(self):
         """Initialize the SystemOverview with all necessary state variables."""
         # Global state variables
@@ -335,10 +335,10 @@ class SystemOverview:
         self.last_button = None
         self.right_drawer = None
         self.fan_change_dialog = None
-        
+
         # Use the global fan control service instance
         self.fan_control_service = globals.fan_control_service
-        
+
         # Ensure the fan control service is initialized
         if self.fan_control_service is None:
             print("Warning: Fan control service not initialized, initializing now...")
@@ -407,45 +407,45 @@ class SystemOverview:
             self.right_drawer.hide()
             self.last_button = None
             return
-        else:  # Last button was a drive 
+        else:  # Last button was a drive
             self.toggle_drive_buttons(self.last_button)
             await self.toggle_fan_buttons()
             self.last_button = button
-        
+
         self.setup_fan_drawer()
 
     def display_profile_sensors(self, profile_name: str, container_classes: str = ''):
         """Display temperature sensors and their current values for a given profile."""
         if not globals.fan_profile_service:
             return
-            
+
         profile = globals.fan_profile_service.get_profile_by_name(profile_name)
         if not profile:
             return
-            
+
         # Get all curves from the profile
         curves = profile.get_all_curves()
         sensors_displayed = set()  # Track which sensors we've already displayed
-        
+
         # Helper function to format sensor display names
         def format_sensor_display_name(sensor_name):
             """Format sensor name for display (remove 'Drives.' prefix for cleaner display)."""
             if sensor_name.startswith('Drives.'):
                 return sensor_name[7:]  # Remove "Drives." prefix for display
             return sensor_name
-        
+
         for curve_id, curve in curves.items():
             if curve.sensor and curve.sensor not in sensors_displayed:
                 sensors_displayed.add(curve.sensor)
-                
+
                 # Display sensor info with dynamically updating temperature
                 with ui.element('div').classes(container_classes):
                     with ui.row().classes('w-full items-center justify-between text-sm text-gray-300'):
                         ui.label(f"{format_sensor_display_name(curve.sensor)}").classes('flex-grow')
-                        
+
                         # Create a label that updates dynamically
                         temp_label = ui.label("N/A").classes('font-mono')
-                        
+
                         # Function to update temperature
                         def update_temp(sensor_name=curve.sensor, label=temp_label):
                             try:
@@ -454,13 +454,13 @@ class SystemOverview:
                                 label.set_text(temp_display)
                             except Exception as e:
                                 label.set_text("Error")
-                        
+
                         # Initial update
                         update_temp()
-                        
+
                         # Set up timer to update every 3 seconds
                         ui.timer(3.0, update_temp)
-        
+
         # If no sensors were displayed (all curves have no sensors assigned), show "No sensors" message
         if not sensors_displayed:
             with ui.element('div').classes(container_classes):
@@ -477,10 +477,10 @@ class SystemOverview:
                 with ui.row().classes('w-full justify-center p-12'):
                     ui.label('No powerboards detected.').classes('text-gray-500 italic')
                 return
-                
+
             # Get available fan profiles
             profile_options = self.fan_control_service.get_fan_profile_options()
-            
+
             if 1 in globals.powerboardDict:  # Display fan speeds
                 # Get current fan wall states
                 wall_1 = self.fan_control_service.fan_walls.get(1)
@@ -491,7 +491,7 @@ class SystemOverview:
                 with ui.row().classes('w-full items-center justify-between px-5 mt-5'):
                     ui.label('Fan Wall 1').tooltip('Hidden fan header hidden under first powerboard.')
                     manual_checkbox_1 = ui.checkbox('Manual', value=wall_1.manual).classes('text-sm')
-                
+
                 with ui.element('div').classes('px-5 pt-4 w-full'):
                     self.slider_list[0] = ui.slider(
                         min=20, max=100
@@ -509,51 +509,51 @@ class SystemOverview:
                     ).classes('w-full')
 
                     profile_select_1.set_enabled(not (wall_1.manual if wall_1 else True))  # Enabled based on manual state
-                
+
                 # Hide/show profile container based on manual state
                 if wall_1 and wall_1.manual:
                     profile_container_1.set_visibility(False)
-                
+
                 # Display selected temperature sensors and values for Fan Wall 1
                 if wall_1 and wall_1.assigned_profile and wall_1.assigned_profile != 'None' and not wall_1.manual:
                     self.display_profile_sensors(wall_1.assigned_profile, 'px-5 pb-2 w-full')
-                
+
                 # Connect checkbox to slider/profile for Fan Wall 1
                 def toggle_fan_wall_1(e):
                     self.slider_list[0].set_enabled(e.value)
                     profile_select_1.set_enabled(not e.value)
                     profile_container_1.set_visibility(not e.value)  # Hide when manual, show when profile mode
-                    
+
                     # Update fan wall service
                     self.fan_control_service.set_manual_mode(1, e.value)
-                    
+
                     # When manual is unchecked, assign the first available fan profile
                     if not e.value and profile_options:
                         first_profile = profile_options[0]
                         profile_select_1.set_value(first_profile)
                         self.fan_control_service.assign_profile_to_wall(1, first_profile)
-                    
+
                     # Refresh drawer to update sensor displays
                     self.setup_fan_drawer()
-                
+
                 manual_checkbox_1.on_value_change(toggle_fan_wall_1)
-                
+
                 # Handle profile selection for Fan Wall 1
                 def on_profile_select_1(e):
                     if not manual_checkbox_1.value:
                         self.fan_control_service.assign_profile_to_wall(1, e.value)
                         # Refresh drawer to update sensor displays
                         self.setup_fan_drawer()
-                
+
                 profile_select_1.on_value_change(on_profile_select_1)
-                    
+
                 ui.separator()
-                
+
                 # Fan Wall 2
                 with ui.row().classes('w-full items-center justify-between px-5 mb-2'):
                     ui.label('Fan Wall 2').tooltip('Hidden fan header hidden under first powerboard.')
                     manual_checkbox_2 = ui.checkbox('Manual', value=wall_2.manual if wall_2 else True).classes('text-sm')
-                
+
                 with ui.element('div').classes('px-5 pt-1 w-full'):
                     self.slider_list[1] = ui.slider(
                         min=20, max=100,
@@ -570,51 +570,51 @@ class SystemOverview:
                         value=wall_2.assigned_profile if wall_2 and wall_2.assigned_profile in profile_options else profile_options[0]
                     ).classes('w-full')
                     profile_select_2.set_enabled(not (wall_2.manual if wall_2 else True))  # Enabled based on manual state
-                
+
                 # Hide/show profile container based on manual state
                 if wall_2 and wall_2.manual:
                     profile_container_2.set_visibility(False)
-                
+
                 # Display selected temperature sensors and values for Fan Wall 2
                 if wall_2 and wall_2.assigned_profile and wall_2.assigned_profile != 'None' and not wall_2.manual:
                     self.display_profile_sensors(wall_2.assigned_profile, 'px-5 pb-2 w-full')
-                
+
                 # Connect checkbox to slider/profile for Fan Wall 2
                 def toggle_fan_wall_2(e):
                     self.slider_list[1].set_enabled(e.value)
                     profile_select_2.set_enabled(not e.value)
                     profile_container_2.set_visibility(not e.value)  # Hide when manual, show when profile mode
-                    
+
                     # Update fan wall service
                     self.fan_control_service.set_manual_mode(2, e.value)
-                    
+
                     # When manual is unchecked, assign the first available fan profile
                     if not e.value and profile_options:
                         first_profile = profile_options[0]
                         profile_select_2.set_value(first_profile)
                         self.fan_control_service.assign_profile_to_wall(2, first_profile)
-                    
+
                     # Refresh drawer to update sensor displays
                     self.setup_fan_drawer()
-                
+
                 manual_checkbox_2.on_value_change(toggle_fan_wall_2)
-                
+
                 # Handle profile selection for Fan Wall 2
                 def on_profile_select_2(e):
                     if not manual_checkbox_2.value:
                         self.fan_control_service.assign_profile_to_wall(2, e.value)
                         # Refresh drawer to update sensor displays
                         self.setup_fan_drawer()
-                
+
                 profile_select_2.on_value_change(on_profile_select_2)
-                
+
                 ui.separator()
-                
+
                 # Fan Wall 3
                 with ui.row().classes('w-full items-center justify-between px-5 mb-2'):
                     ui.label('Fan Wall 3').tooltip('Exposed fan headers on the first powerboard.')
                     manual_checkbox_3 = ui.checkbox('Manual', value=wall_3.manual if wall_3 else True).classes('text-sm')
-                
+
                 with ui.element('div').classes('px-5 pt-1 w-full'):
                     self.slider_list[2] = ui.slider(
                         min=20, max=100
@@ -631,68 +631,68 @@ class SystemOverview:
                         value=wall_3.assigned_profile if wall_3 and wall_3.assigned_profile in profile_options else profile_options[0]
                     ).classes('w-full')
                     profile_select_3.set_enabled(not (wall_3.manual if wall_3 else True))  # Enabled based on manual state
-                
+
                 # Hide/show profile container based on manual state
                 if wall_3 and wall_3.manual:
                     profile_container_3.set_visibility(False)
-                
+
                 # Display selected temperature sensors and values for Fan Wall 3
                 if wall_3 and wall_3.assigned_profile and wall_3.assigned_profile != 'None' and not wall_3.manual:
                     self.display_profile_sensors(wall_3.assigned_profile, 'px-5 pb-2 w-full')
-                
+
                 # Connect checkbox to slider/profile for Fan Wall 3
                 def toggle_fan_wall_3(e):
                     self.slider_list[2].set_enabled(e.value)
                     profile_select_3.set_enabled(not e.value)
                     profile_container_3.set_visibility(not e.value)  # Hide when manual, show when profile mode
-                    
+
                     # Update fan wall service
                     self.fan_control_service.set_manual_mode(3, e.value)
-                    
+
                     # When manual is unchecked, assign the first available fan profile
                     if not e.value and profile_options:
                         first_profile = profile_options[0]
                         profile_select_3.set_value(first_profile)
                         self.fan_control_service.assign_profile_to_wall(3, first_profile)
-                    
+
                     # Refresh drawer to update sensor displays
                     self.setup_fan_drawer()
-                
+
                 manual_checkbox_3.on_value_change(toggle_fan_wall_3)
-                
+
                 # Handle profile selection for Fan Wall 3
                 def on_profile_select_3(e):
                     if not manual_checkbox_3.value:
                         self.fan_control_service.assign_profile_to_wall(3, e.value)
                         # Refresh drawer to update sensor displays
                         self.setup_fan_drawer()
-                
+
                 profile_select_3.on_value_change(on_profile_select_3)
-                
+
                 ui.separator()
-                
-            
+
+
             if 2 in globals.powerboardDict:  # Display auxiliary fan control
                 pb: Powerboard = globals.powerboardDict[2]
                 # Get current saved auxiliary fan speed from powerboard 2
                 aux_pwm_tuple = pb.get_saved_fan_pwm()
                 aux_pwm = aux_pwm_tuple[2]  # Use row 3 as the auxiliary speed
-                
+
                 # Get auxiliary fan wall state
                 wall_aux = self.fan_control_service.fan_walls.get(4)
-                
+
                 # Auxiliary Fans
                 with ui.row().classes('w-full items-center justify-between px-5 mb-2'):
                     ui.label('Auxiliary Fans').tooltip('Fan headers on the second powerboard.')
                     manual_checkbox_aux = ui.checkbox('Manual', value=wall_aux.manual if wall_aux else True).classes('text-sm')
-                
+
                 with ui.element('div').classes('px-5 pt-1 w-full'):
                     self.slider_list[3] = ui.slider(
                         min=20, max=100
                     ).props('label-always')
                     self.slider_list[3].bind_value(self.fan_control_service.fan_walls[4], 'current_speed')
                     self.slider_list[3].set_enabled(wall_aux.manual if wall_aux else True)  # Enabled based on manual state
-                
+
                 # Profile selection for Auxiliary Fans - hide when manual mode is enabled
                 profile_container_aux = ui.element('div').classes('px-5 pb-2 w-full')
                 with profile_container_aux:
@@ -702,56 +702,56 @@ class SystemOverview:
                         value=wall_aux.assigned_profile if wall_aux and wall_aux.assigned_profile in profile_options else profile_options[0]
                     ).classes('w-full')
                     profile_select_aux.set_enabled(not (wall_aux.manual if wall_aux else True))  # Enabled based on manual state
-                
+
                 # Hide/show profile container based on manual state
                 if wall_aux and wall_aux.manual:
                     profile_container_aux.set_visibility(False)
-                
+
                 # Display selected temperature sensors and values for Auxiliary Fans
                 if wall_aux and wall_aux.assigned_profile and wall_aux.assigned_profile != 'None' and not wall_aux.manual:
                     self.display_profile_sensors(wall_aux.assigned_profile, 'px-5 pb-2 w-full')
-                
+
                 # Connect checkbox to slider/profile for Auxiliary Fans
                 def toggle_auxiliary_fans(e):
                     self.slider_list[3].set_enabled(e.value)
                     profile_select_aux.set_enabled(not e.value)
                     profile_container_aux.set_visibility(not e.value)  # Hide when manual, show when profile mode
-                    
+
                     # Update auxiliary fan wall service
                     self.fan_control_service.set_manual_mode(4, e.value)
-                    
+
                     # When manual is unchecked, assign the first available fan profile
                     if not e.value and profile_options:
                         first_profile = profile_options[0]
                         profile_select_aux.set_value(first_profile)
                         self.fan_control_service.assign_profile_to_wall(4, first_profile)
-                    
+
                     # Refresh drawer to update sensor displays
                     self.setup_fan_drawer()
-                
+
                 manual_checkbox_aux.on_value_change(toggle_auxiliary_fans)
-                
+
                 # Handle profile selection for Auxiliary Fans
                 def on_profile_select_aux(e):
                     if not manual_checkbox_aux.value:
                         self.fan_control_service.assign_profile_to_wall(4, e.value)
                         # Refresh drawer to update sensor displays
                         self.setup_fan_drawer()
-                
+
                 profile_select_aux.on_value_change(on_profile_select_aux)
-                
+
                 ui.separator()
 
     def display_drive_attributes(self, button: DriveButton):
         """Display drive attributes in the right drawer."""
         self.right_drawer.clear()
-        
+
         with self.right_drawer:
             columns = [
                 {'name': 'attribute', 'label': 'Attribute', 'field': 'attribute', 'required': True, 'align': 'left'},
                 {'name': 'value', 'label': 'Value', 'field': 'value', 'required': True, 'align': 'right'},
             ]
-            
+
             d = button.assigned_drive
             rows = [
                 {'attribute': 'Model', 'value': d.model},
@@ -774,12 +774,12 @@ class SystemOverview:
                     edit_icon.set_visibility(False)
                 with ui.menu().props('fit'):
                     ui.menu_item('Remove drive', lambda: button.clear_drive())
-            
+
             ui.table(columns=columns, rows=rows, row_key='attribute').classes('w-full')
             with ui.element('dive').classes('w-full px-4'):
                 ui.button(
-                    "Show All", 
-                    icon='open_in_new', 
+                    "Show All",
+                    icon='open_in_new',
                     on_click=lambda: self.display_full_drive_attributes(d)
                 ).classes('w-full border-solid border-2 border-[#ffdd00]').props('flat color="white"')
 
@@ -790,7 +790,7 @@ class SystemOverview:
             self.right_drawer.show()
             self.last_button = button
         elif self.last_button in self.fan_buttons_list:  # Last click was fans
-            await self.toggle_fan_buttons() 
+            await self.toggle_fan_buttons()
             self.toggle_drive_buttons(button)
             self.last_button = button
         elif self.last_button == button:  # Same button clicked, deselect
@@ -811,7 +811,7 @@ class SystemOverview:
         """Set up the drive assignment drawer."""
         with self.right_drawer:
             self.right_drawer.clear()
-            
+
             with ui.item().classes('w-full bg-[#ffdd00]'):
                 with ui.item_section():
                     ui.item_label("Assign Drive").style('color: black')
@@ -819,13 +819,13 @@ class SystemOverview:
                 ui.select(
                     label="Select or search drive",
                     options=[
-                        globals.drivesList[k].model + ' (' + globals.drivesList[k].serial_num + ')' 
+                        globals.drivesList[k].model + ' (' + globals.drivesList[k].serial_num + ')'
                         for k in globals.drivesList
-                    ], 
+                    ],
                     with_input=True,
                     on_change=lambda e: (
-                        button.assign_drive(e.value), 
-                        globals.layoutState.insert_drive(button.card, e.value, button.button_index), 
+                        button.assign_drive(e.value),
+                        globals.layoutState.insert_drive(button.card, e.value, button.button_index),
                         self.display_drive_attributes(button)
                     )
                 ).classes('w-full')
@@ -855,11 +855,11 @@ class SystemOverview:
                 "layout": "mixed"
             }
         }
-        
+
         config = backplane_configs.get(backplane_type)
         if not config:
             return
-            
+
         with card:
             if config["layout"] == "single_column":
                 with ui.element('div').classes(f'f-shape{cage} h-full flex items-center justify-center p-1'):
@@ -873,13 +873,13 @@ class SystemOverview:
                     ui.element('div').classes(f'extension-patch patch-top-arm-bottom{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-bottom{cage}')
-                        
+
             elif config["layout"] == "two_column":
                 with ui.element('div').classes(f'f-shape{cage} grid grid-cols-2 gap-1 flex items-center justify-center h-full p-1'):
                     with ui.element('col1').classes('col-span-1 h-full'):
                         for i in range(6):
                             button = config["button_class"](card, i, backplane.drives_hashes[i])
-                            button.on_click_handler = self.select_drive  
+                            button.on_click_handler = self.select_drive
                             button.on('click', lambda b=button: self.select_drive(b))
                             card.buttons.append(button.classes('truncate'))
                     with ui.element('col2').classes('col-span-1 h-full'):
@@ -892,7 +892,7 @@ class SystemOverview:
                     ui.element('div').classes(f'extension-patch patch-top-arm-bottom{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-bottom{cage}')
-                            
+
             elif config["layout"] == "mixed":
                 with ui.element('div').classes(f'f-shape{cage} h-full flex items-center justify-center p-1'):
                     with ui.element('col').classes('col h-full flex justify-center'):
@@ -906,16 +906,16 @@ class SystemOverview:
                             else: # HDD buttons
                                 button.style('height: 28%;')
                             card.buttons.append(button)
-                
+
                     ui.element('div').classes(f'extension-patch patch-top-arm-bottom{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-bottom{cage}')
-            
+
             with ui.context_menu():
                 ui.menu_item(
-                    'Remove Backplane', 
+                    'Remove Backplane',
                     on_click=lambda: (
-                        globals.layoutState.remove_backplane(card), 
+                        globals.layoutState.remove_backplane(card),
                         self.add_backplane_button(card, card.__class__)
                     )
                 )
@@ -932,34 +932,62 @@ class SystemOverview:
                 self.last_button = None
                 self.right_drawer.hide()
         card.buttons.clear()
-        
+
+        # Get chassis orientation to determine backplane options
+        orientation = globals.layoutState.get_chassis_orientation()
+        chassis_type = globals.layoutState.get_product()
+
+        # Determine if this card should show standard options based on orientation and position
+        if orientation == "normal":
+            # Normal orientation: use original card class logic
+            show_standard_options = (card_class == StdPlaceHolderCard)
+        else:
+            # Inverted orientation: swap only the top and bottom rows
+            if chassis_type == "Hako-Core":
+                if card.index in {0, 1, 2}:  # Top row - give 2+2 options (was standard)
+                    show_standard_options = False
+                elif card.index in {9, 10, 11}:  # Bottom row - give standard options (was 2+2)
+                    show_standard_options = True
+                else:  # All middle positions (3,4,5,6,7,8) - keep original standard options
+                    show_standard_options = True
+            elif chassis_type == "Hako-Core Mini":
+                if card.index in {0, 1}:  # Top row - give 2+2 options (was standard)
+                    show_standard_options = False
+                elif card.index in {6, 7}:  # Bottom row - give standard options (was 2+2)
+                    show_standard_options = True
+                else:  # All middle positions (2,3,4,5) - keep original standard options
+                    show_standard_options = True
+            else:
+                # Fallback to original logic
+                show_standard_options = (card_class == StdPlaceHolderCard)
+
         with card.style(f'{element_justified}'):
-            if card_class == StdPlaceHolderCard:
-                    # Use the custom component just like a normal dropdown
-                with FadingDropdown('Add Backplane', icon='add').menu:
+            with FadingDropdown('Add Backplane', icon='add').menu:
+                if show_standard_options:
+                    # Show standard backplane options (4 HDD, 12 SSD)
                     ui.menu_item(
-                        '4 HDD Backplane', 
+                        '4 HDD Backplane',
                         on_click=lambda: self.setup_backplane_buttons(
-                            card, 
-                            globals.layoutState.insert_backplane(card, "STD4HDD"), 
+                            card,
+                            globals.layoutState.insert_backplane(card, "STD4HDD"),
                             card.index
                         )
                     )
                     ui.menu_item(
-                        '12 SSD Backplane', 
+                        '12 SSD Backplane',
                         on_click=lambda: self.setup_backplane_buttons(
-                            card, 
-                            globals.layoutState.insert_backplane(card, "STD12SSD"), 
+                            card,
+                            globals.layoutState.insert_backplane(card, "STD12SSD"),
                             card.index
                         )
                     )
-            else:  # SmlPlaceHolderCard
-                with FadingDropdown('Add Backplane', icon='add').menu:
+                else:
+                    # Show small backplane options (2+2 only)
                     ui.menu_item(
-                        '2+2 Backplane', 
+                        '2+2 Backplane',
                         on_click=lambda: self.setup_backplane_buttons(
-                            card, 
-                            globals.layoutState.insert_backplane(card, "SML2+2"), 
+                            card,
+                            globals.layoutState.insert_backplane(card, "SML2+2"),
                             card.index
                         )
                     )
@@ -972,7 +1000,7 @@ class SystemOverview:
         card.clear()
         self.fan_buttons_list.clear()
         self.wattage_card_list.clear()
-        
+
         layout_configs = {
             "Hako-Core": {
                 "grid_cols": 12,
@@ -989,16 +1017,16 @@ class SystemOverview:
                 "sml_cards": 2
             }
         }
-        
+
         config = layout_configs[chassis_type]
-        
+
         # Create a grid container inside the card element
         with card:
             with ui.element('div').classes(
                 f'grid grid-cols-{config["grid_cols"]} gap-0'
             ).style('height: 98.9dvh; width: 70dvw; min-width: 1200px; min-height: 800px; grid-template-rows: 4% 25% 25% 25% 21%;') as grid_container:
                 # Use the grid container for the rest of the method
-                
+
                 # Create fan buttons and wattage cards in the proper order
                 for i in range(2):
                     RPMCard(i)
@@ -1012,7 +1040,7 @@ class SystemOverview:
                 # Create backplane cards
                 if not globals.layoutState.is_empty():
                     backplane_list = globals.layoutState.get_backplanes()
-                    
+
                     # Standard cards
                     for i, bp in enumerate(backplane_list[:config["std_cards"]]):
                         if i < 2: # insert fan div for first part
@@ -1023,12 +1051,12 @@ class SystemOverview:
                             self.setup_backplane_buttons(card_widget, bp, i)
                         else:
                             self.add_backplane_button(card_widget, StdPlaceHolderCard)
-                            
+
                         if i == 2 and chassis_type == "Hako-Core":  # Reversed for the last one
                             row2_3 = FanRowButtons(self.select_fans)
                             self.fan_buttons_list.extend(row2_3.row_Of_Buttons)
 
-                    
+
                     # Small cards
                     start_idx = 9 if chassis_type == "Hako-Core" else 6
                     for i, bp in enumerate(backplane_list[start_idx:start_idx + config["sml_cards"]]):
@@ -1061,21 +1089,21 @@ class SystemOverview:
                     chassis_dialog.close()
                     # Force UI update after closing dialog
                     self.create_chassis_layout(main_content, "Hako-Core")
-                
+
                 def select_hako_core_mini():
                     chassis_dialog.close()
                     self.create_chassis_layout(main_content, "Hako-Core Mini")
-                
+
                 ui.button(
                     'Hako-Core',
                     on_click=select_hako_core
                 ).classes('border-solid border-2 border-[#ffdd00] px-8 py-4').props('flat color="white"')
-                
+
                 ui.button(
-                    'Hako-Core Mini', 
+                    'Hako-Core Mini',
                     on_click=select_hako_core_mini
                 ).classes('border-solid border-2 border-[#ffdd00] px-8 py-4').props('flat color="white"')
-        
+
         chassis_dialog.open()
 
     def create_ui(self):
@@ -1084,7 +1112,7 @@ class SystemOverview:
             with ui.element('div').classes('flex w-full').style('justify-content: safe center;'):
                 with ui.element('div').classes('pseudo-extend') as main_content:
                     current_chassis = globals.layoutState.get_product()
-                    
+
                     if current_chassis is None:
                         # Show chassis selection dialog
                         self.show_chassis_selection_dialog(main_content)
@@ -1099,11 +1127,11 @@ class SystemOverview:
             with ui.dialog() as self.fan_change_dialog, ui.card():
                 ui.label('Apply changes?')
                 ui.button(
-                    'Apply', 
+                    'Apply',
                     on_click=lambda: self.fan_change_dialog.submit("Apply")
                 ).on_click(self.set_fan_speed)
                 ui.button(
-                    'Discard', 
+                    'Discard',
                     on_click=lambda: self.fan_change_dialog.submit("Discard")
                 ).on_click(self.dialog_handler_discard)
 
@@ -1113,19 +1141,19 @@ def overviewPage():
 
     The powerboard is an object that gets refreshed every 3 seconds for new values and the respective
     UI elements are updated. During the refresh, the powerboard is unable to take commands for 2 seconds.
-    Fan control commands are queued if the powerboard is busy. A toast notification will popup indicating 
+    Fan control commands are queued if the powerboard is busy. A toast notification will popup indicating
     a fan command has been executed.
 
     The drive information is taken from smartctl commands so S.M.A.R.T. must be enabled on the drives to
-    be shown. 
+    be shown.
     """
     # Set up static file serving for CSS
     app.add_static_files('/css', 'css')
-    
+
     # Add CSS file references
     ui.add_head_html('<link rel="stylesheet" type="text/css" href="/css/f-shape.css">')
     ui.add_head_html('<link rel="stylesheet" type="text/css" href="/css/f-shape-rotated.css">')
     ui.add_head_html('<link rel="stylesheet" type="text/css" href="/css/pseudo-extend.css">')
-    
+
     overview = SystemOverview()
     overview.create_ui()

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -6,18 +6,18 @@ import page_layout
 @require_auth
 def settingsPage():
     """Settings page for chassis layout and powerboard information."""
-    
+
     # Use a mutable object to store the flag so it can be accessed in nested functions
     state_flags = {'ignoring_change': False}
-    
+
     # Store UI element references
     ui_refs = {'model_switch': None, 'sn_switch': None}
-    
+
     # Ensure at least one switch is on during initialization
     if not globals.layoutState.get_model_display() and not globals.layoutState.get_sn_display():
         # If both are off, turn on model display by default
         globals.layoutState.set_model_display(True)
-    
+
     def change_product(new_product):
         """Change the chassis product and reset layout."""
         globals.layoutState.reset_chassis()
@@ -46,14 +46,14 @@ def settingsPage():
         # Ignore programmatic changes
         if state_flags['ignoring_change']:
             return
-            
+
         current_product = globals.layoutState.get_product()
         new_product = e.value
-        
+
         # Only show dialog if actually changing to a different product
         if new_product != current_product:
             reset_dialog(new_product)
-        
+
     def reset_dialog(new_product):
         """Show confirmation dialog when changing chassis layout."""
         def on_no():
@@ -62,18 +62,18 @@ def settingsPage():
             product_select.set_value(globals.layoutState.get_product())
             state_flags['ignoring_change'] = False
             dialog.close()
-            
+
         with ui.dialog().props('persistent') as dialog, ui.card():
             ui.label('Changing layouts will reset backplanes and drives. Continue?')
             with ui.row().classes('w-full justify-center'):
                 ui.button('Yes', on_click=lambda: (change_product(new_product), dialog.close())).classes('border-solid border-2 border-[#ffdd00]').props('flat color="white"')
                 ui.button('No', on_click=on_no).classes('border-solid border-2 border-[#ffdd00]').props('flat color="white"')
         dialog.open()
-    
+
     def get_powerboard_info():
         """Get powerboard information for table display."""
         powerboard_data = []
-        
+
         for position in [1, 2]:
             if position in globals.powerboardDict:
                 pb = globals.powerboardDict[position]
@@ -81,7 +81,7 @@ def settingsPage():
                     # Get connection port info
                     port = getattr(pb, '_serial_instance', None)
                     port_name = port.port if port and hasattr(port, 'port') else 'Unknown'
-                    
+
                     powerboard_data.append({
                         'port': port_name,
                         'hardware_rev': pb.hardware_revision if hasattr(pb, 'hardware_revision') else 'Unknown',
@@ -96,16 +96,16 @@ def settingsPage():
                         'firmware_ver': 'Error',
                         'location': 'Error'
                     })
-        
+
         return powerboard_data
-    
+
     def create_powerboard_table():
         """Create and return powerboard information table."""
         powerboard_data = get_powerboard_info()
-        
+
         if not powerboard_data:
             return ui.label('No powerboards detected.').classes('text-gray-500 italic')
-        
+
         # Define table columns
         columns = [
             {'name': 'port', 'label': 'Serial Port', 'field': 'port', 'required': True, 'align': 'left'},
@@ -113,72 +113,72 @@ def settingsPage():
             {'name': 'firmware_ver', 'label': 'Firmware Ver', 'field': 'firmware_ver', 'required': True, 'align': 'center'},
             {'name': 'location', 'label': 'Location', 'field': 'location', 'required': True, 'align': 'center'}
         ]
-        
+
         return ui.table(
-            columns=columns, 
-            rows=powerboard_data, 
+            columns=columns,
+            rows=powerboard_data,
             row_key='location'
         ).classes('w-full')
-    
+
     def get_pwm_values():
         """Get current saved PWM values from powerboards."""
         pwm_data = {}
-        
+
         # Get powerboard 1 PWM values
         if 1 in globals.powerboardDict:
             pb1_pwm = globals.powerboardDict[1].get_saved_fan_pwm()
             pwm_data['pb1'] = {
                 'row1': pb1_pwm[0],
-                'row2': pb1_pwm[1], 
+                'row2': pb1_pwm[1],
                 'row3': pb1_pwm[2]
             }
-        
+
         # Get powerboard 2 PWM values
         if 2 in globals.powerboardDict:
             pb2_pwm = globals.powerboardDict[2].get_saved_fan_pwm()
             pwm_data['pb2'] = {
                 'aux': pb2_pwm[2]  # Use third value for auxiliary
             }
-        
+
         return pwm_data
-    
+
     def create_pwm_settings():
         """Create PWM settings interface."""
         pwm_data = get_pwm_values()
-        
+
         if not pwm_data:
             return ui.label('No powerboards detected for PWM settings.').classes('text-gray-500 italic')
-        
+
         # Store PWM input references
         pwm_inputs = {}
-        
+
         async def apply_pwm_settings():
             """Apply the PWM settings using fan control service."""
             try:
                 # Get values from inputs
                 pb1_values = [0, 0, 0]
                 pb2_aux = 100
-                
+
                 if 'pb1' in pwm_data:
                     pb1_values[0] = int(pwm_inputs['pb1_row1'].value)
                     pb1_values[1] = int(pwm_inputs['pb1_row2'].value)
                     pb1_values[2] = int(pwm_inputs['pb1_row3'].value)
-                
+
                 if 'pb2' in pwm_data:
                     pb2_aux = int(pwm_inputs['pb2_aux'].value)
-                
+
                 # Use fan control service to set the speeds
                 await globals.fan_control_service.set_fan_speed(
                     pb1_values[0], pb1_values[1], pb1_values[2], pb2_aux
                 )
-                
-                ui.notify("PWM settings applied successfully!", 
+
+                ui.notify("PWM settings applied successfully!",
                          position='bottom-right', type='positive', group=False)
-                
+
             except Exception as e:
-                ui.notify(f"Error applying PWM settings: {str(e)}", 
+                ui.notify(f"Error applying PWM settings: {str(e)}",
                          position='bottom-right', type='negative', group=False)
-        
+
         with ui.column().classes('w-full gap-4'):
             # Powerboard 1 settings
             if 'pb1' in pwm_data:
@@ -192,7 +192,7 @@ def settingsPage():
                                 value=int(pwm_data['pb1']['row1'])
                             ).classes('w-32')
                             ui.label().bind_text_from(pwm_inputs['pb1_row1'], 'value', lambda v: f'{int(v)}%')
-                        
+
                         with ui.column().classes('items-center gap-2'):
                             ui.label('Row 2 PWM')
                             pwm_inputs['pb1_row2'] = ui.slider(
@@ -200,7 +200,7 @@ def settingsPage():
                                 value=int(pwm_data['pb1']['row2'])
                             ).classes('w-32')
                             ui.label().bind_text_from(pwm_inputs['pb1_row2'], 'value', lambda v: f'{int(v)}%')
-                        
+
                         with ui.column().classes('items-center gap-2'):
                             ui.label('Row 3 PWM')
                             pwm_inputs['pb1_row3'] = ui.slider(
@@ -208,7 +208,7 @@ def settingsPage():
                                 value=int(pwm_data['pb1']['row3'])
                             ).classes('w-32')
                             ui.label().bind_text_from(pwm_inputs['pb1_row3'], 'value', lambda v: f'{int(v)}%')
-            
+
             # Powerboard 2 settings (show only if exists)
             if 'pb2' in pwm_data:
                 with ui.card().classes('w-full'):
@@ -220,14 +220,14 @@ def settingsPage():
                             value=int(pwm_data['pb2']['aux'])
                         ).classes('w-64')
                         ui.label().bind_text_from(pwm_inputs['pb2_aux'], 'value', lambda v: f'{int(v)}%')
-            
+
             # Apply button
             with ui.row().classes('justify-center w-full mt-4'):
                 ui.button(
-                    'Apply PWM Settings', 
+                    'Apply PWM Settings',
                     on_click=apply_pwm_settings
                 ).classes('border-solid border-2 border-[#ffdd00] text-white px-6 py-2').props('flat')
-    
+
     # Main settings UI
     with page_layout.frame('Settings'):
         with ui.element('div').classes('flex w-full').style('justify-content: safe center;'):
@@ -237,31 +237,69 @@ def settingsPage():
                 with ui.grid(columns=2).classes('gap-0').style('grid-auto-rows: 1fr;'):
                     ui.label('Chassis Layout:').classes('flex justify-start items-center')
                     product_select = ui.select(
-                        ['Hako-Core', 'Hako-Core Mini'], 
-                        value=globals.layoutState.get_product(), 
+                        ['Hako-Core', 'Hako-Core Mini'],
+                        value=globals.layoutState.get_product(),
                         on_change=handle_product_change
                     )
-                    
-                    ui.label('Show drive model:').classes('flex justify-start items-center ') 
+
+                    ui.label('Show drive model:').classes('flex justify-start items-center ')
                     ui_refs['model_switch'] = ui.switch(value=globals.layoutState.get_model_display(), on_change=lambda e: change_model_display(e.value)).style('justify-content:end;')
 
-                    ui.label('Show drive serial #:').classes('flex justify-start items-center') 
+                    ui.label('Show drive serial #:').classes('flex justify-start items-center')
                     ui_refs['sn_switch'] = ui.switch(value=globals.layoutState.get_sn_display(), on_change=lambda e: change_sn_display(e.value)).style('justify-content:end;')
 
+                    ui.label('Chassis orientation:').classes('flex justify-start items-center')
+                    orientation_switch = ui.switch(
+                        text='Inverted',
+                        value=globals.layoutState.get_chassis_orientation() == "inverted",
+                        on_change=lambda e: globals.layoutState.set_chassis_orientation("inverted" if e.value else "normal")
+                    ).style('justify-content:end;')
+                    orientation_switch.tooltip('Toggle if your chassis is physically mounted inverted')
+
+                ui.separator().classes('my-4')
+
+                # Clear All Backplanes Section
+                with ui.row().classes('w-full justify-center'):
+                    def clear_all_backplanes():
+                        """Clear all backplanes with confirmation dialog."""
+                        def on_confirm():
+                            globals.layoutState.clear_all_backplanes()
+                            ui.notify("All backplanes cleared successfully!",
+                                     position='bottom-right', type='positive', group=False)
+                            confirm_dialog.close()
+
+                        def on_cancel():
+                            confirm_dialog.close()
+
+                        with ui.dialog().props('persistent') as confirm_dialog, ui.card().classes('p-6'):
+                            ui.label('Clear All Backplanes?').classes('text-xl font-bold mb-4')
+                            ui.label('This will remove all backplanes and their drive assignments. This action cannot be undone.').classes('text-sm text-gray-400 mb-4')
+                            with ui.row().classes('w-full justify-center gap-4'):
+                                ui.button('Yes, Clear All', on_click=on_confirm).classes('border-solid border-2 border-red-500 text-red-500 px-6 py-2').props('flat')
+                                ui.button('Cancel', on_click=on_cancel).classes('border-solid border-2 border-[#ffdd00] text-white px-6 py-2').props('flat')
+                        confirm_dialog.open()
+
+                    ui.button(
+                        'Clear All Backplanes',
+                        on_click=clear_all_backplanes,
+                        icon='delete_sweep'
+                    ).classes('border-solid border-2 border-red-500 text-red-500 px-6 py-2').props('flat')
+                    ui.label('Remove all backplanes and drive assignments').classes('text-xs text-gray-500 ml-2 self-center')
+
                 ui.separator().classes('mb-6')
-                
+
                 # Powerboard Information Section
                 with ui.column().classes('w-full') as powerboard_container:
                     ui.label('Powerboard Information').classes('text-xl font-bold mb-4')
                     create_powerboard_table()
-                
+
                 ui.separator().classes('mb-6')
-                
+
                 # PWM Settings Section
                 with ui.column().classes('w-full') as pwm_container:
                     ui.label('Default Fan Speed').classes('text-xl font-bold mb-4')
                     ui.label('These will be used when the system starts and persist between power cycles.').classes('text-sm text-gray-500 mb-2')
                     create_pwm_settings()
-                
+
                 # Additional spacing
                 ui.space().classes('h-2')


### PR DESCRIPTION
Introduces chassis orientation (normal/inverted) to Chassis, with config persistence and methods to get/set orientation. Updates overview and settings pages to use orientation for backplane options and adds a switch to the settings page for toggling orientation. Backplane selection logic in overview_page.py now adapts to orientation and chassis type, swapping top/bottom row options when inverted.