### PR TITLE
Add Custom Chassis Name Display

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,4 +41,7 @@ if __name__ == '__mp_main__':
     # No authentication provided, open site
     authentication.validate_environment()
 
-ui.run(title="Hako Foundry", favicon="res/Hako_Logo.png", dark=True, storage_secret=hashlib.sha256(os.getenv('SECRET').encode()).hexdigest())
+
+chassis_name = globals.layoutState.get_chassis_name()
+title = f"{chassis_name}" if chassis_name else "Hako Foundry"
+ui.run(title=title,favicon="res/Hako_Logo.png",dark=True,storage_secret=hashlib.sha256(os.getenv('SECRET').encode()).hexdigest())

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -257,6 +257,10 @@ def settingsPage():
                 # Chassis Layout Section
                 ui.label('Chassis Configuration').classes('text-xl font-bold mb-4')
                 with ui.grid(columns=2).classes('gap-0 w-full').style('grid-auto-rows: 1fr;'):
+                    # Allow Custom Chassis Naming
+                    ui.label('Chassis Name:').classes('flex justify-start items-center')
+                    ui_refs['chassis_name_input'] = ui.input(value=globals.layoutState.get_chassis_name(),placeholder='Enter chassis name...',on_change=lambda e: change_chassis_name(e.value)).style('justify-content:end;')
+                    
                     ui.label('Chassis Layout:').classes('flex justify-start items-center')
                     product_select = ui.select(
                         ['Hako-Core', 'Hako-Core Mini'],


### PR DESCRIPTION
Adds the ability to set and display a custom chassis name in the web interface to help users quickly identify which machine is being configured. 