### PR TITLE
Visual and Workflow Improvements

### DIFF
--- a/all_pages.py
+++ b/all_pages.py
@@ -2,8 +2,10 @@ from nicegui import ui
 from pages.overview_page import overviewPage
 from pages.settings_page import settingsPage
 from pages.fan_curve_page import fanCurvePage
+from pages.powerboards_page import powerboardsPage
 """Class for mapping all pages."""
 def create() -> None:
     ui.page('/overview')(overviewPage)
     ui.page('/settings')(settingsPage)
     ui.page('/curves')(fanCurvePage)
+    ui.page('/powerboards')(powerboardsPage)

--- a/foundry_state.py
+++ b/foundry_state.py
@@ -19,6 +19,11 @@ class FoundryStateError(Exception):
     pass
 
 
+class DriveStandbyError(Exception):
+    """Raised when a drive is in standby/sleep and should not be woken."""
+    pass
+
+
 @dataclass
 class DriveInfo:
     """Data class for drive information."""
@@ -108,8 +113,12 @@ class Drive:
 class SmartCtlInterface:
     """Interface for smartctl operations."""
     @staticmethod
-    def execute_command(args: str, timeout: int = 30) -> str:
-        """Execute smartctl command with timeout and error handling."""
+    def execute_command(args: str, timeout: int = 30) -> tuple[str, int]:
+        """Execute smartctl command with timeout and error handling.
+
+        Returns:
+            Tuple of (stdout, returncode).
+        """
         try:
             cmd = f"smartctl {args}"
             result = subprocess.run(
@@ -124,7 +133,7 @@ class SmartCtlInterface:
             if result.returncode < 0:  # Negative return codes indicate serious errors
                 raise FoundryStateError(f"smartctl command failed: {result.stderr}")
 
-            return result.stdout
+            return result.stdout, result.returncode
 
         except subprocess.TimeoutExpired:
             logger.error(f"smartctl command timed out: {cmd}")
@@ -137,7 +146,7 @@ class SmartCtlInterface:
     def get_drive_ids(cls) -> List[str]:
         """Get list of available drive IDs."""
         try:
-            output = cls.execute_command("--scan")
+            output, _ = cls.execute_command("--scan")
             lines = output.strip().splitlines()
             device_list = [line.strip() for line in lines if line.strip()]
             logger.info(f"Found {len(device_list)} drives")
@@ -151,7 +160,12 @@ class SmartCtlInterface:
         """Get S.M.A.R.T. data for a specific device."""
         try:
             device_path = device_id.split(' ')[0]
-            json_output = cls.execute_command(f"--xall --json --device auto {device_path}")
+            json_output, returncode = cls.execute_command(f"-n standby --xall --json --device auto {device_path}")
+
+            # Exit code 2 means the drive is in standby/sleep — do not wake it.
+            if returncode == 2:
+                logger.debug(f"Drive {device_path} is spun down, skipping query")
+                raise DriveStandbyError(device_path)
 
             if not json_output.strip():
                 logger.warning(f"No output from smartctl for device {device_path}")
@@ -166,6 +180,8 @@ class SmartCtlInterface:
 
             return drive
 
+        except DriveStandbyError:
+            raise  # Let caller handle standby drives
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON for device {device_id}: {e}")
             return None
@@ -269,8 +285,9 @@ class SmartCtlInterface:
 class DriveManager:
     """Manages drive detection and caching."""
 
-    def __init__(self, debug,cache_duration: int = 300):  # 5 minutes cache
+    def __init__(self, debug, cache_duration: int = 300):  # 5 minutes cache
         self._drive_cache: Dict[int, Drive] = {}
+        self._device_path_to_hash: Dict[str, int] = {}  # device path → drive hash
         self._last_scan_time: float = 0
         self._cache_duration = cache_duration
         self._debug = debug
@@ -300,13 +317,24 @@ class DriveManager:
         drive_ids = SmartCtlInterface.get_drive_ids()
 
         for device_id in drive_ids:
+            device_path = device_id.split(' ')[0]
             try:
                 drive = SmartCtlInterface.get_smart_data(device_id, self._debug)
                 if drive:
                     drives[drive.hash] = drive
+                    self._device_path_to_hash[device_path] = drive.hash
                     logger.info(f"Added drive: {drive.model} ({drive.serial_num})")
                 else:
                     logger.warning(f"Failed to get data for device: {device_id}")
+
+            except DriveStandbyError:
+                # Drive is asleep — preserve its cached data so it isn't evicted.
+                cached_hash = self._device_path_to_hash.get(device_path)
+                if cached_hash is not None and cached_hash in self._drive_cache:
+                    drives[cached_hash] = self._drive_cache[cached_hash]
+                    logger.debug(f"Drive {device_path} is in standby, retaining cached data")
+                else:
+                    logger.debug(f"Drive {device_path} is in standby, no cached data available yet")
 
             except Exception as e:
                 logger.error(f"Error processing device {device_id}: {e}")

--- a/page_layout.py
+++ b/page_layout.py
@@ -43,6 +43,12 @@ def frame(navtitle: str):
                     ui.icon('timeline').classes('material-symbols-outlined')
                 with ui.item_section():
                     ui.item_label('Fan Curves').classes('text-nowrap')
+
+            with ui.item().props('clickable v-ripple').on_click(lambda: ui.navigate.to('/powerboards')):
+                with ui.item_section().props('avatar'):
+                    ui.icon('developer_board').classes('material-symbols-outlined')
+                with ui.item_section():
+                    ui.item_label('Powerboards').classes('text-nowrap')
             ui.separator()
             
             with ui.item().props('clickable').on_click(lambda: ui.navigate.to('/settings')):

--- a/pages/fan_curve_page.py
+++ b/pages/fan_curve_page.py
@@ -555,6 +555,11 @@ def fanCurvePage():
                                 "grid_cols": 8,
                                 "std_cards": 6,
                                 "sml_cards": 2
+                            },
+                            "HF-L1": {
+                                "grid_cols": 4,
+                                "std_cards": 3,
+                                "sml_cards": 1
                             }
                         }
                         
@@ -575,7 +580,7 @@ def fanCurvePage():
                                     drive_cards.append(card_widget)
                                 
                                 # Small cards
-                                start_idx = 9 if current_chassis == "Hako-Core" else 6
+                                start_idx = config["std_cards"]
                                 for i, bp in enumerate(backplane_list[start_idx:start_idx + config["sml_cards"]]):
                                     card_widget = create_drive_card(i + start_idx, bp, toggle_drive_selection, "sml", selected_drives)
                                     drive_cards.append(card_widget)

--- a/pages/overview_page.py
+++ b/pages/overview_page.py
@@ -1077,7 +1077,7 @@ class SystemOverview:
             with FadingDropdown('Add Backplane', icon='add').menu:
                 if card_class == StdPlaceHolderCard:
                     ui.menu_item(
-                        '4 HDD Backplane',
+                        '4 HDD/U.2 Backplane',
                         on_click=lambda: self.setup_backplane_buttons(
                             card, globals.layoutState.insert_backplane(card, "STD4HDD"), card.index
                         )

--- a/pages/overview_page.py
+++ b/pages/overview_page.py
@@ -1036,13 +1036,31 @@ class SystemOverview:
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-bottom{cage}')
 
+            def confirm_remove_backplane(c=card):
+                def on_confirm():
+                    globals.layoutState.remove_backplane(c)
+                    self.add_backplane_button(c, c.__class__)
+                    confirm_dialog.close()
+
+                with ui.dialog().props('persistent') as confirm_dialog, ui.card().classes('p-6'):
+                    ui.label('Change Backplane?').classes('text-xl font-bold mb-4')
+                    ui.label('This will remove the backplane and all its drive assignments.').classes('text-sm text-gray-400 mb-4')
+                    with ui.row().classes('w-full justify-center gap-4'):
+                        ui.button('Yes, Remove', on_click=on_confirm).classes('border-solid border-2 border-red-500 text-red-500 px-6 py-2').props('flat')
+                        ui.button('Cancel', on_click=confirm_dialog.close).classes('border-solid border-2 border-[#ffdd00] text-white px-6 py-2').props('flat')
+                confirm_dialog.open()
+
+            ui.button(
+                icon='swap_horiz',
+                on_click=confirm_remove_backplane
+            ).props('flat round dense size=xs color=grey-5').classes(
+                'absolute top-0 right-0 z-10 opacity-30 hover:opacity-100'
+            ).tooltip('Change backplane type')
+
             with ui.context_menu():
                 ui.menu_item(
                     'Remove Backplane',
-                    on_click=lambda: (
-                        globals.layoutState.remove_backplane(card),
-                        self.add_backplane_button(card, card.__class__)
-                    )
+                    on_click=lambda c=card: confirm_remove_backplane(c)
                 )
 
     def add_backplane_button(self, card, card_class):

--- a/pages/overview_page.py
+++ b/pages/overview_page.py
@@ -218,11 +218,12 @@ class StdPlaceHolderCard(ui.element):
         self.tabsRight = True
 
         if globals.layoutState.get_product() == "Hako-Core":
-            if (index % 3 == 1): # 2nd row
+            if (index % 3 == 1): # 2nd column
                 self.tabsRight = False
-        if globals.layoutState.get_product() == "Hako-Core Mini":
-            if (index % 2 == 1): # 2nd row
+        elif globals.layoutState.get_product() == "Hako-Core Mini":
+            if (index % 2 == 1): # 2nd column
                 self.tabsRight = False
+        # HF-L1 has only one column — tabsRight stays True
 
         with self.classes('p-0 flex').style(f'aspect-ratio: 1/1; width: 100%; height: 100%; grid-area: {grid_position};'):
             # Will be populated by parent function
@@ -239,11 +240,12 @@ class SmlPlaceHolderCard(ui.element):
         self.tabsRight = True
 
         if globals.layoutState.get_product() == "Hako-Core":
-            if (index % 3 == 1): # 2nd row
+            if (index % 3 == 1): # 2nd column
                 self.tabsRight = False
-        if globals.layoutState.get_product() == "Hako-Core Mini":
-            if (index % 2 == 1): # 2nd row
+        elif globals.layoutState.get_product() == "Hako-Core Mini":
+            if (index % 2 == 1): # 2nd column
                 self.tabsRight = False
+        # HF-L1 has only one column — tabsRight stays True
 
         with self.classes('p-0 flex h-full').style(f'aspect-ratio: 100/87; width: 100%; max-height: 100%; grid-area: {grid_position};'):
             # Will be populated by parent function
@@ -387,6 +389,36 @@ class ChassisLayoutManager:
                     "rpm_positions": ["rpm1", "rpm2"],
                     "watt_positions": ["watt1", "watt2"]
                 }
+            },
+            "HF-L1": {
+                "normal": {
+                    "grid_template_areas": """
+                        "rpm1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 rpm2"
+                        "fan1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 fan2"
+                        "fan1 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 fan2"
+                        "fan1 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 fan2"
+                        "fan1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 fan2"
+                    """,
+                    "fan_positions": ["fan1", "fan2"],
+                    "backplane_positions": ["bp1", "bp2", "bp3"],
+                    "small_positions": ["sml1"],
+                    "rpm_positions": ["rpm1", "rpm2"],
+                    "watt_positions": ["watt1"]
+                },
+                "inverted": {
+                    "grid_template_areas": """
+                        "rpm2 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 watt1 rpm1"
+                        "fan2 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 sml1 fan1"
+                        "fan2 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 bp3 fan1"
+                        "fan2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 bp2 fan1"
+                        "fan2 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 bp1 fan1"
+                    """,
+                    "fan_positions": ["fan1", "fan2"],
+                    "backplane_positions": ["bp1", "bp2", "bp3"],
+                    "small_positions": ["sml1"],
+                    "rpm_positions": ["rpm1", "rpm2"],
+                    "watt_positions": ["watt1"]
+                }
             }
         }
 
@@ -430,6 +462,8 @@ class SystemOverview:
             return i in {0, 1, 3, 4, 6, 7, 9, 10}
         if chassis == "Hako-Core Mini":
             return i in {0, 1, 2, 3, 4, 5, 6, 7}
+        if chassis == "HF-L1":
+            return i in {0, 1, 2, 3}
         return False
 
     def should_rotate_backplane(self, index: int) -> bool:
@@ -440,6 +474,8 @@ class SystemOverview:
             return index in {0,1, 3,4, 6,7, 9,10}
         if chassis == "Hako-Core Mini":
             return index in {0,1, 2,3, 4,5}
+        if chassis == "HF-L1":
+            return index in {0, 1, 2, 3}
         return False
 
     def set_slider_value_without_callback(self, slider_index: int, value: float):
@@ -1115,8 +1151,13 @@ class SystemOverview:
 
         with card:
             # Set width based on chassis type
-            card_width = '50dvw' if chassis_type == "Hako-Core Mini" else '70dvw'
-            # Set grid template rows based on orientation
+            if chassis_type == "Hako-Core Mini":
+                card_width = '50dvw'
+            elif chassis_type == "HF-L1":
+                card_width = '35dvw'
+            else:
+                card_width = '70dvw'
+            # Set grid template rows based on orientation (all chassis share the same 5-row structure)
             grid_rows = '4% 21% 25% 25% 25%' if is_inverted else '4% 25% 25% 25% 21%'
             with ui.element('div').classes('gap-0').style(
                 f'height: 98.9dvh; width: {card_width}; min-width: 800px; min-height: 800px; '
@@ -1189,6 +1230,10 @@ class SystemOverview:
                     chassis_dialog.close()
                     self.create_chassis_layout(main_content, "Hako-Core Mini")
 
+                def select_hf_l1():
+                    chassis_dialog.close()
+                    self.create_chassis_layout(main_content, "HF-L1")
+
                 ui.button(
                     'Hako-Core',
                     on_click=select_hako_core
@@ -1197,6 +1242,11 @@ class SystemOverview:
                 ui.button(
                     'Hako-Core Mini',
                     on_click=select_hako_core_mini
+                ).classes('border-solid border-2 border-[#ffdd00] px-8 py-4').props('flat color="white"')
+
+                ui.button(
+                    'HF-L1',
+                    on_click=select_hf_l1
                 ).classes('border-solid border-2 border-[#ffdd00] px-8 py-4').props('flat color="white"')
 
         chassis_dialog.open()
@@ -1213,7 +1263,7 @@ class SystemOverview:
                     if current_chassis is None:
                         # Show chassis selection dialog
                         self.show_chassis_selection_dialog(main_content)
-                    elif current_chassis in ["Hako-Core", "Hako-Core Mini"]:
+                    elif current_chassis in ["Hako-Core", "Hako-Core Mini", "HF-L1"]:
                         self.create_chassis_layout(main_content, current_chassis)
 
             # Create drawers and dialogs

--- a/pages/overview_page.py
+++ b/pages/overview_page.py
@@ -976,7 +976,7 @@ class SystemOverview:
         config = backplane_configs[backplane_type]
 
         # --- apply flip on the parent card element ---
-        card.classes(add="bp-rotatable" + (" flip-180" if need_flip else ""))
+        card.classes(add="bp-rotatable relative" + (" flip-180" if need_flip else ""))
 
         with card:
             if config["layout"] == "single_column":
@@ -1036,23 +1036,20 @@ class SystemOverview:
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-bottom{cage}')
 
-            def confirm_remove_backplane(c=card):
-                def on_confirm():
-                    globals.layoutState.remove_backplane(c)
-                    self.add_backplane_button(c, c.__class__)
-                    confirm_dialog.close()
-
-                with ui.dialog().props('persistent') as confirm_dialog, ui.card().classes('p-6'):
-                    ui.label('Change Backplane?').classes('text-xl font-bold mb-4')
-                    ui.label('This will remove the backplane and all its drive assignments.').classes('text-sm text-gray-400 mb-4')
-                    with ui.row().classes('w-full justify-center gap-4'):
-                        ui.button('Yes, Remove', on_click=on_confirm).classes('border-solid border-2 border-red-500 text-red-500 px-6 py-2').props('flat')
-                        ui.button('Cancel', on_click=confirm_dialog.close).classes('border-solid border-2 border-[#ffdd00] text-white px-6 py-2').props('flat')
-                confirm_dialog.open()
+            with ui.dialog().props('persistent') as confirm_dialog, ui.card().classes('p-6'):
+                ui.label('Change Backplane?').classes('text-xl font-bold mb-4')
+                ui.label('This will remove the backplane and all its drive assignments.').classes('text-sm text-gray-400 mb-4')
+                with ui.row().classes('w-full justify-center gap-4'):
+                    ui.button('Yes, Remove', on_click=lambda c=card: (
+                        globals.layoutState.remove_backplane(c),
+                        self.add_backplane_button(c, c.__class__),
+                        confirm_dialog.close()
+                    )).classes('border-solid border-2 border-red-500 text-red-500 px-6 py-2').props('flat')
+                    ui.button('Cancel', on_click=confirm_dialog.close).classes('border-solid border-2 border-[#ffdd00] text-white px-6 py-2').props('flat')
 
             ui.button(
                 icon='swap_horiz',
-                on_click=confirm_remove_backplane
+                on_click=confirm_dialog.open
             ).props('flat round dense size=xs color=grey-5').classes(
                 'absolute top-0 right-0 z-10 opacity-30 hover:opacity-100'
             ).tooltip('Change backplane type')
@@ -1060,7 +1057,7 @@ class SystemOverview:
             with ui.context_menu():
                 ui.menu_item(
                     'Remove Backplane',
-                    on_click=lambda c=card: confirm_remove_backplane(c)
+                    on_click=confirm_dialog.open
                 )
 
     def add_backplane_button(self, card, card_class):

--- a/pages/powerboards_page.py
+++ b/pages/powerboards_page.py
@@ -56,9 +56,6 @@ async def powerboardsPage():
                         ui.label('No powerboards detected.').classes('text-gray-400 text-lg')
                 return
 
-            # ── Debug toggle ──────────────────────────────────────────────
-            debug_toggle = ui.switch('Debug').classes('mb-4 text-gray-400')
-
             for pb_id, pb in sorted(globals.powerboardDict.items()):
                 with ui.card().classes('w-full mb-6 bg-[#1b1b1b] p-0 overflow-hidden'):
 
@@ -68,13 +65,15 @@ async def powerboardsPage():
                             ui.icon('memory').classes('text-[#ffdd00]')
                             ui.label(f'Powerboard {pb.location}').classes('text-lg font-bold')
                         connected = pb.is_connected
-                        with ui.row().classes('items-center gap-1'):
-                            ui.icon('circle').classes(
-                                f'text-xs {"text-green-400" if connected else "text-red-400"}'
-                            )
-                            ui.label('Connected' if connected else 'Disconnected').classes(
-                                f'text-sm {"text-green-400" if connected else "text-red-400"}'
-                            )
+                        with ui.row().classes('items-center gap-4'):
+                            with ui.row().classes('items-center gap-1'):
+                                ui.icon('circle').classes(
+                                    f'text-xs {"text-green-400" if connected else "text-red-400"}'
+                                )
+                                ui.label('Connected' if connected else 'Disconnected').classes(
+                                    f'text-sm {"text-green-400" if connected else "text-red-400"}'
+                                )
+                            debug_toggle = ui.switch('Debug').props('color="yellowhako" dense').classes('text-xs text-gray-400')
 
                     # ── Board identity ────────────────────────────────────────
                     with ui.row().classes('px-5 py-3 gap-8 flex-wrap'):

--- a/pages/powerboards_page.py
+++ b/pages/powerboards_page.py
@@ -12,7 +12,7 @@ import page_layout
 logger = logging.getLogger("foundry_logger")
 
 
-def _make_refresh(pb, rpm_labels, pwm_labels, watt_labels, shunt_labels):
+def _make_refresh(pb, rpm_labels, pwm_labels, watt_labels, shunt_labels, raw_labels):
     """Return an async refresh callback bound to a specific powerboard's UI labels."""
     async def refresh():
         try:
@@ -34,6 +34,10 @@ def _make_refresh(pb, rpm_labels, pwm_labels, watt_labels, shunt_labels):
                 for i, label in enumerate(shunt_labels):
                     label.set_text(f'{int(pb._current_wattage[i])} W')
 
+            raw_labels['tach'].set_text(pb._raw_tach or '—')
+            raw_labels['wattage'].set_text(pb._raw_wattage or '—')
+            raw_labels['pwm'].set_text(pb._raw_pwm or '—')
+
         except Exception as e:
             logger.warning(f'Error refreshing powerboard {pb.location} display: {e}')
     return refresh
@@ -49,6 +53,9 @@ async def powerboardsPage():
                         ui.icon('power_off').classes('text-gray-500 text-3xl')
                         ui.label('No powerboards detected.').classes('text-gray-400 text-lg')
                 return
+
+            # ── Debug toggle ──────────────────────────────────────────────
+            debug_toggle = ui.switch('Debug').classes('mb-4 text-gray-400')
 
             for pb_id, pb in sorted(globals.powerboardDict.items()):
                 with ui.card().classes('w-full mb-6 bg-[#1b1b1b] p-0 overflow-hidden'):
@@ -170,11 +177,31 @@ async def powerboardsPage():
                         ui.label('Control Mode:').classes('text-sm text-gray-400')
                         ui.label(mode).classes(f'font-mono text-sm {mode_color}')
 
+                    # ── Debug panel ───────────────────────────────────────────
+                    with ui.element('div').classes('px-5 pb-4') as debug_panel:
+                        ui.separator().classes('mb-3')
+                        ui.label('Raw Serial').classes(
+                            'text-xs font-semibold text-gray-400 uppercase tracking-widest mb-2'
+                        )
+                        raw_labels = {}
+                        for key, attr, label_text in [
+                            ('tach',    '_raw_tach',    'Tach (T:)'),
+                            ('wattage', '_raw_wattage', 'Wattage (W:)'),
+                            ('pwm',     '_raw_pwm',     'PWM (P:)'),
+                        ]:
+                            with ui.row().classes('gap-3 items-baseline'):
+                                ui.label(label_text).classes('text-xs text-gray-500 w-28')
+                                raw_labels[key] = ui.label(
+                                    getattr(pb, attr) or '—'
+                                ).classes('font-mono text-xs text-gray-300')
+                    debug_panel.bind_visibility_from(debug_toggle, 'value')
+
                     # ── Live refresh timer ────────────────────────────────────
                     ui.timer(3.0, _make_refresh(
                         pb,
                         rpm_labels,
                         pwm_labels,
                         [watt_12_label, watt_34_label, watt_total_label],
-                        shunt_labels
+                        shunt_labels,
+                        raw_labels,
                     ))

--- a/pages/powerboards_page.py
+++ b/pages/powerboards_page.py
@@ -1,0 +1,180 @@
+"""
+Powerboards Page
+
+Displays live telemetry for each connected powerboard: fan header RPM and PWM,
+per-section and per-shunt wattage, board identity, and control mode.
+"""
+import logging
+from nicegui import ui, run
+import globals
+import page_layout
+
+logger = logging.getLogger("foundry_logger")
+
+
+def _make_refresh(pb, rpm_labels, pwm_labels, watt_labels, shunt_labels):
+    """Return an async refresh callback bound to a specific powerboard's UI labels."""
+    async def refresh():
+        try:
+            r1, r2, r3 = pb.get_running_fan_pwm()
+            rpm_labels[0].set_text(f'{pb.row1_rpm or 0:,}')
+            rpm_labels[1].set_text(f'{pb.row2_rpm or 0:,}')
+            rpm_labels[2].set_text(f'{pb.row3_rpm or 0:,}')
+            pwm_labels[0].set_text(f'{r1}%')
+            pwm_labels[1].set_text(f'{r2}%')
+            pwm_labels[2].set_text(f'{r3}%')
+
+            sec12 = pb.watt_sec_1_2 or 0
+            sec34 = pb.watt_sec_3_4 or 0
+            watt_labels[0].set_text(f'{sec12} W')
+            watt_labels[1].set_text(f'{sec34} W')
+            watt_labels[2].set_text(f'{sec12 + sec34} W')
+
+            if pb._current_wattage and shunt_labels:
+                for i, label in enumerate(shunt_labels):
+                    label.set_text(f'{int(pb._current_wattage[i])} W')
+
+        except Exception as e:
+            logger.warning(f'Error refreshing powerboard {pb.location} display: {e}')
+    return refresh
+
+
+async def powerboardsPage():
+    with page_layout.frame('Powerboards'):
+        with ui.element('div').classes('p-6 w-full max-w-4xl'):
+
+            if not globals.powerboardDict:
+                with ui.card().classes('p-8 bg-[#1b1b1b]'):
+                    with ui.row().classes('items-center gap-3'):
+                        ui.icon('power_off').classes('text-gray-500 text-3xl')
+                        ui.label('No powerboards detected.').classes('text-gray-400 text-lg')
+                return
+
+            for pb_id, pb in sorted(globals.powerboardDict.items()):
+                with ui.card().classes('w-full mb-6 bg-[#1b1b1b] p-0 overflow-hidden'):
+
+                    # ── Header ────────────────────────────────────────────────
+                    with ui.row().classes('w-full items-center justify-between px-5 py-3 bg-[#242424]'):
+                        with ui.row().classes('items-center gap-3'):
+                            ui.icon('memory').classes('text-[#ffdd00]')
+                            ui.label(f'Powerboard {pb.location}').classes('text-lg font-bold')
+                        connected = pb.is_connected
+                        with ui.row().classes('items-center gap-1'):
+                            ui.icon('circle').classes(
+                                f'text-xs {"text-green-400" if connected else "text-red-400"}'
+                            )
+                            ui.label('Connected' if connected else 'Disconnected').classes(
+                                f'text-sm {"text-green-400" if connected else "text-red-400"}'
+                            )
+
+                    # ── Board identity ────────────────────────────────────────
+                    with ui.row().classes('px-5 py-3 gap-8 flex-wrap'):
+                        for label_text, value in [
+                            ('Hardware Rev', pb.hardware_revision),
+                            ('Firmware Ver', pb.firmware_version),
+                            ('Serial Port',  pb._serial_instance.port),
+                        ]:
+                            with ui.column().classes('gap-0'):
+                                ui.label(label_text).classes('text-xs text-gray-400 uppercase tracking-wide')
+                                ui.label(value).classes('font-mono text-sm')
+
+                    ui.separator()
+
+                    # ── Fan headers ───────────────────────────────────────────
+                    with ui.element('div').classes('px-5 pt-3 pb-1'):
+                        ui.label('Fan Headers').classes(
+                            'text-xs font-semibold text-gray-400 uppercase tracking-widest mb-2'
+                        )
+                    with ui.grid(columns=4).classes('px-5 pb-4 gap-x-4 gap-y-1 w-full'):
+                        # Column headers
+                        ui.label('')
+                        for row_name in ['Row 1', 'Row 2', 'Row 3']:
+                            ui.label(row_name).classes('text-center text-sm font-semibold text-[#ffdd00]')
+
+                        # RPM row
+                        ui.label('RPM').classes('text-gray-400 text-sm self-center')
+                        rpm_labels = [
+                            ui.label(f'{pb.row1_rpm or 0:,}').classes('text-center font-mono'),
+                            ui.label(f'{pb.row2_rpm or 0:,}').classes('text-center font-mono'),
+                            ui.label(f'{pb.row3_rpm or 0:,}').classes('text-center font-mono'),
+                        ]
+
+                        # PWM row
+                        ui.label('PWM').classes('text-gray-400 text-sm self-center')
+                        r1, r2, r3 = pb.get_running_fan_pwm()
+                        pwm_labels = [
+                            ui.label(f'{r1}%').classes('text-center font-mono'),
+                            ui.label(f'{r2}%').classes('text-center font-mono'),
+                            ui.label(f'{r3}%').classes('text-center font-mono'),
+                        ]
+
+                        # Saved PWM row
+                        ui.label('Saved PWM').classes('text-gray-400 text-sm self-center')
+                        s1, s2, s3 = pb.get_saved_fan_pwm()
+                        for val in [s1, s2, s3]:
+                            ui.label(f'{val}%').classes('text-center font-mono text-gray-500')
+
+                    ui.separator()
+
+                    # ── Power ─────────────────────────────────────────────────
+                    with ui.element('div').classes('px-5 pt-3 pb-1'):
+                        ui.label('Power').classes(
+                            'text-xs font-semibold text-gray-400 uppercase tracking-widest mb-2'
+                        )
+                    sec12 = pb.watt_sec_1_2 or 0
+                    sec34 = pb.watt_sec_3_4 or 0
+                    with ui.row().classes('px-5 pb-3 gap-8 flex-wrap items-end'):
+                        for label_text, initial, accent in [
+                            ('Section 1–2', f'{sec12} W',          False),
+                            ('Section 3–4', f'{sec34} W',          False),
+                            ('Total',       f'{sec12 + sec34} W',  True),
+                        ]:
+                            with ui.column().classes('gap-0'):
+                                ui.label(label_text).classes('text-xs text-gray-400 uppercase tracking-wide')
+                                lbl = ui.label(initial).classes(
+                                    f'font-mono text-lg {"text-[#ffdd00]" if accent else ""}'
+                                )
+                                if label_text == 'Section 1–2':
+                                    watt_12_label = lbl
+                                elif label_text == 'Section 3–4':
+                                    watt_34_label = lbl
+                                else:
+                                    watt_total_label = lbl
+
+                    # Per-shunt breakdown
+                    shunt_labels = []
+                    if pb._current_wattage:
+                        with ui.element('div').classes('px-5 pb-4'):
+                            ui.label('Shunt breakdown').classes('text-xs text-gray-500 mb-1')
+                            with ui.row().classes('gap-6'):
+                                for i, w in enumerate(pb._current_wattage):
+                                    with ui.column().classes('gap-0'):
+                                        ui.label(f'Shunt {i + 1}').classes('text-xs text-gray-500')
+                                        shunt_labels.append(
+                                            ui.label(f'{int(w)} W').classes('font-mono text-sm text-gray-300')
+                                        )
+
+                    ui.separator()
+
+                    # ── Control mode (jumper) ─────────────────────────────────
+                    try:
+                        jumper = await run.io_bound(pb.get_jumper_state)
+                        mode = 'Motherboard' if jumper == 1 else 'Powerboard'
+                        mode_color = 'text-yellow-400' if jumper == 1 else 'text-green-400'
+                    except Exception:
+                        mode = 'Unknown'
+                        mode_color = 'text-gray-500'
+
+                    with ui.row().classes('px-5 py-3 items-center gap-2'):
+                        ui.icon('tune').classes('text-gray-400 text-sm')
+                        ui.label('Control Mode:').classes('text-sm text-gray-400')
+                        ui.label(mode).classes(f'font-mono text-sm {mode_color}')
+
+                    # ── Live refresh timer ────────────────────────────────────
+                    ui.timer(3.0, _make_refresh(
+                        pb,
+                        rpm_labels,
+                        pwm_labels,
+                        [watt_12_label, watt_34_label, watt_total_label],
+                        shunt_labels
+                    ))

--- a/pages/powerboards_page.py
+++ b/pages/powerboards_page.py
@@ -37,6 +37,8 @@ def _make_refresh(pb, rpm_labels, pwm_labels, watt_labels, shunt_labels, raw_lab
             raw_labels['tach'].set_text(pb._raw_tach or '—')
             raw_labels['wattage'].set_text(pb._raw_wattage or '—')
             raw_labels['pwm'].set_text(pb._raw_pwm or '—')
+            raw_labels['metadata'].set_text(pb._raw_metadata or '—')
+            raw_labels['jumper'].set_text(pb._raw_jumper or '—')
 
         except Exception as e:
             logger.warning(f'Error refreshing powerboard {pb.location} display: {e}')
@@ -185,9 +187,11 @@ async def powerboardsPage():
                         )
                         raw_labels = {}
                         for key, attr, label_text in [
-                            ('tach',    '_raw_tach',    'Tach (T:)'),
-                            ('wattage', '_raw_wattage', 'Wattage (W:)'),
-                            ('pwm',     '_raw_pwm',     'PWM (P:)'),
+                            ('tach',     '_raw_tach',      'Tach (T:)'),
+                            ('wattage',  '_raw_wattage',   'Wattage (W:)'),
+                            ('pwm',      '_raw_pwm',       'PWM (P:)'),
+                            ('metadata', '_raw_metadata',  'Metadata (V:)'),
+                            ('jumper',   '_raw_jumper',    'Jumper (J:)'),
                         ]:
                             with ui.row().classes('gap-3 items-baseline'):
                                 ui.label(label_text).classes('text-xs text-gray-500 w-28')

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -259,7 +259,7 @@ def settingsPage():
                 with ui.grid(columns=2).classes('gap-0 w-full').style('grid-auto-rows: 1fr;'):
                     ui.label('Chassis Layout:').classes('flex justify-start items-center')
                     product_select = ui.select(
-                        ['Hako-Core', 'Hako-Core Mini'],
+                        ['Hako-Core', 'Hako-Core Mini', 'HF-L1'],
                         value=globals.layoutState.get_product(),
                         on_change=handle_product_change
                     )

--- a/powerboard.py
+++ b/powerboard.py
@@ -146,6 +146,11 @@ class Powerboard:
 
         self.watt_sec_1_2: int = None
         self.watt_sec_3_4: int = None
+
+        # Raw serial responses for debug display
+        self._raw_tach: Optional[str] = None
+        self._raw_wattage: Optional[str] = None
+        self._raw_pwm: Optional[str] = None
         
         # Update all powerboard state
         self.update_powerboard_state()
@@ -177,6 +182,7 @@ class Powerboard:
         response = self._send_command(self.COMMANDS['get_pwm'])
         if not response:
             raise PowerboardError("Failed to read initial PWM state")
+        self._raw_pwm = response
             
         try:
             pwm_values = [int(x) for x in response.split(',')]
@@ -365,6 +371,7 @@ class Powerboard:
         """Update fan RPM readings from powerboard."""
         with self.semaphore:
             response = self._send_command(self.COMMANDS['get_tach'])
+        self._raw_tach = response
             
         try:
             rpm_values = [int(x) for x in response.split(',')]
@@ -385,6 +392,7 @@ class Powerboard:
         """Update power usage readings from powerboard."""
         with self.semaphore:
             response = self._send_command(self.COMMANDS['get_wattage'])
+        self._raw_wattage = response
             
         try:
             analog_readings = [float(x) for x in response.split(',')]

--- a/powerboard.py
+++ b/powerboard.py
@@ -115,7 +115,14 @@ class Powerboard:
         # Initialize semaphore for thread-safe serial communication
         self.semaphore = threading.Semaphore()
         self._serial_instance = self._create_serial_connection(com_port)
-        
+
+        # Raw serial responses for debug display (must be declared before any serial calls)
+        self._raw_tach: Optional[str] = None
+        self._raw_wattage: Optional[str] = None
+        self._raw_pwm: Optional[str] = None
+        self._raw_metadata: Optional[str] = None
+        self._raw_jumper: Optional[str] = None
+
         self._read_initial_metadata()
         self._read_initial_pwm_state()
         # Set the fan speed to the eeprom values
@@ -147,13 +154,6 @@ class Powerboard:
         self.watt_sec_1_2: int = None
         self.watt_sec_3_4: int = None
 
-        # Raw serial responses for debug display
-        self._raw_tach: Optional[str] = None
-        self._raw_wattage: Optional[str] = None
-        self._raw_pwm: Optional[str] = None
-        self._raw_metadata: Optional[str] = None
-        self._raw_jumper: Optional[str] = None
-        
         # Update all powerboard state
         self.update_powerboard_state()
 

--- a/powerboard.py
+++ b/powerboard.py
@@ -151,6 +151,8 @@ class Powerboard:
         self._raw_tach: Optional[str] = None
         self._raw_wattage: Optional[str] = None
         self._raw_pwm: Optional[str] = None
+        self._raw_metadata: Optional[str] = None
+        self._raw_jumper: Optional[str] = None
         
         # Update all powerboard state
         self.update_powerboard_state()
@@ -287,16 +289,16 @@ class Powerboard:
 
     def get_board_metadata(self) -> Tuple[str, str, str]:
         """Get board metadata including hardware revision, firmware version, and location.
-        
+
         Returns:
             Tuple of (hardware_rev, firmware_ver, location)
-            
+
         Raises:
             PowerboardError: If command fails
         """
         with self.semaphore:
             response = self._send_command(self.COMMANDS['get_metadata'])
-            
+        self._raw_metadata = response
         try:
             parts = response.split(',')
             if len(parts) != 3:
@@ -437,16 +439,16 @@ class Powerboard:
 
     def get_jumper_state(self) -> int:
         """Get jumper status for fan control mode.
-        
+
         Returns:
             1 if jumper is on motherboard fan control, 0 if on powerboard fan control
-            
+
         Raises:
             PowerboardError: If command fails
         """
         with self.semaphore:
             response = self._send_command(self.COMMANDS['get_jumper'])
-            
+        self._raw_jumper = response
         try:
             return int(response)
         except ValueError as e:


### PR DESCRIPTION
Sorry, messed up the PR and originally wanted this as a clean one.

- smartctl queries now respect drive power state hopefully spun-down drives are no longer woken on every poll. Standby drives retain their last-known data in the cache rather than being evicted.
- A swap_horiz icon button is visible on each backplane, and the existing right-click "Remove Backplane" context menu item now both trigger a confirmation dialog before proceeding.
- Updated "4 HDD Backplane" label to "4 HDD/U.2 Backplane" to reflect U.2 drive support.
- Add a Powerboard page to view attributes from each board in a singular location. A debug toggle exists to see the raw output from the serial connection. 

<img width="883" height="828" alt="Screenshot_20260322_074350" src="https://github.com/user-attachments/assets/8ebd75fb-06d6-4d54-a12f-dc3916d869bb" />

Tested on 2.0 boards but additional verification should be done for newer boards. 
