### PR TITLE
feat: proposal for an API to monitor the PDB's & control fans

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,207 @@
+# Hako Foundry REST API
+
+Exposes powerboard metrics and fan control over HTTP. All endpoints require API key authentication.
+
+## Setup
+
+API keys are managed in the Foundry UI under **Settings > API Keys**. Click **Generate New API Key**, give it a name, and copy the key when shown as it is displayed only once.
+
+Keys are stored as SHA-256 hashes in `config/api_config.json`. If no keys have been created, all requests will return `503 Service Unavailable`.
+
+## Authentication
+
+Pass your key in the `X-API-Key` request header:
+
+```sh
+curl -H "X-API-Key: hf-api_your-key-here" http://localhost:8080/api/v1/status
+```
+
+---
+
+## Endpoints
+
+### Service
+
+#### `GET /api/v1/status`
+
+Returns service health and the number of connected powerboards.
+
+**Response**
+```json
+{
+  "status": "ok",
+  "powerboards_connected": 2,
+  "powerboard_locations": [1, 2]
+}
+```
+
+---
+
+### Powerboards
+
+#### `GET /api/v1/powerboards`
+
+Returns metrics for all connected powerboards.
+
+**Response**
+```json
+{
+  "powerboards": [
+    { "location": 1, ... },
+    { "location": 2, ... }
+  ]
+}
+```
+
+#### `GET /api/v1/powerboards/{location}`
+
+Returns metrics for a single powerboard. `location` is `1` or `2`.
+
+**Response**
+```json
+{
+  "location": 1,
+  "hardware_revision": "...",
+  "firmware_version": "...",
+  "is_connected": true,
+  "fan": {
+    "pwm_percent": { "row1": 60, "row2": 60, "row3": 60 },
+    "rpm":         { "row1": 1200, "row2": 1180, "row3": null }
+  },
+  "power": {
+    "shunt1_watts": 45.2,
+    "shunt2_watts": 38.1,
+    "shunt3_watts": null,
+    "shunt4_watts": null,
+    "section_1_2_watts": 83.3,
+    "section_3_4_watts": null,
+    "total_watts": 83
+  }
+}
+```
+
+> RPM and wattage fields may be `null` if the first poll hasn't completed yet.
+
+**Errors**
+| Status | Reason |
+|--------|--------|
+| `404`  | No powerboard at that location |
+
+---
+
+### Fans
+
+#### `GET /api/v1/fans/status`
+
+Returns PWM, RPM, and override state for all fan walls.
+
+**Response**
+```json
+{
+  "override_active": false,
+  "walls": [
+    {
+      "wall_id": 1,
+      "key": "1",
+      "name": "Wall 1",
+      "pwm_percent": 60,
+      "rpm": 1200,
+      "manual": false,
+      "assigned_profile": "balanced",
+      "override_active": false,
+      "powerboard_id": 1,
+      "header_index": 0
+    }
+  ]
+}
+```
+
+#### `GET /api/v1/fans/status/{wall_key}`
+
+Same as above, filtered to one wall. Valid `wall_key` values:
+
+| Key | Wall |
+|-----|------|
+| `1` | Fan Wall 1 |
+| `2` | Fan Wall 2 |
+| `3` | Fan Wall 3 |
+| `aux1` or `4` | Auxiliary Fan 1 |
+| `aux2` or `5` | Auxiliary Fan 2 |
+| `aux3` or `6` | Auxiliary Fan 3 |
+
+**Errors**
+| Status | Reason |
+|--------|--------|
+| `404`  | Wall not found |
+| `422`  | Unknown wall identifier |
+| `503`  | Fan control service unavailable |
+
+---
+
+#### `POST /api/v1/fans/override`
+
+Engage or release a temporary fan speed override. Overrides set walls to manual mode without writing to the config on disk. The original wall states are snapshot on the first engagement and restored on release.
+
+**Request body**
+```json
+{
+  "active": true,
+  "pwm_percent": 80,
+  "walls": {
+    "1": 90,
+    "aux1": 60,
+    "aux3": 50
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `active` | bool | yes | `true` to engage, `false` to release |
+| `pwm_percent` | int 0–100 | no | Global speed applied to all walls not listed in `walls` |
+| `walls` | object | no | Per-wall speeds. Keys: `"1"`–`"3"` (main), `"4"`/`"aux1"`, `"5"`/`"aux2"`, `"6"`/`"aux3"` (auxiliary). Values: 0–100 |
+
+When `active=true`, at least one of `pwm_percent` or `walls` must be provided. Per-wall entries in `walls` take precedence over `pwm_percent`.
+
+Subsequent calls with `active=true` update speeds without replacing the original snapshot.
+
+**Response (engaged)**
+```json
+{
+  "override_active": true,
+  "applied": { "Fan Wall 1": 90, "Auxiliary Fan 1": 60, "Fan Wall 2": 80 },
+  "skipped": [{ "wall": "Auxiliary Fan 3", "reason": "no hardware assignment" }],
+  "snapshot_taken": true
+}
+```
+
+**Response (released)**
+```json
+{
+  "override_active": false,
+  "detail": "Override released. Wall states restored."
+}
+```
+
+**Errors**
+| Status | Reason |
+|--------|--------|
+| `422`  | `active=true` with no speed targets, or invalid wall key / PWM value |
+| `503`  | Fan control service unavailable |
+
+---
+
+## Error format
+
+All errors follow FastAPI's standard detail envelope:
+
+```json
+{ "detail": "Human-readable error message." }
+```
+
+## Authentication errors
+
+| Status | Reason |
+|--------|--------|
+| `401`  | Missing or invalid `X-API-Key` |
+| `503`  | No API keys configured on the server |

--- a/api.py
+++ b/api.py
@@ -1,0 +1,373 @@
+"""
+REST API for Hako Foundry
+
+Exposes powerboard metrics over HTTP with API key authentication.
+Keys are managed via Settings > API Keys and stored in config/api_config.json.
+
+Endpoints:
+  GET  /api/v1/status                    — service health and connected powerboard count
+  GET  /api/v1/powerboards               — metrics for all connected powerboards
+  GET  /api/v1/powerboards/{location}    — metrics for a single powerboard (1 or 2)
+  GET  /api/v1/fans/status               — PWM, RPM, and override state for all fan walls
+  GET  /api/v1/fans/status/{wall_id}     — same, filtered to one wall (1, 2, 3, aux1, aux2, aux3)
+  POST /api/v1/fans/override             — engage or release a temporary fan speed override
+"""
+
+import logging
+from typing import Dict, Optional
+
+from fastapi import Depends, HTTPException
+from fastapi.security.api_key import APIKeyHeader
+from nicegui import app, run
+from pydantic import BaseModel, field_validator
+
+import globals
+from api_key_manager import api_key_manager
+from powerboard import PowerboardError
+
+# Wall ID aliases for auxiliary fan walls
+_WALL_ALIAS = {"aux1": 4, "aux2": 5, "aux3": 6}
+
+# Snapshot taken on the first POST {"active": true} during a session.
+# Cleared when the override is released. Never persisted to disk.
+# Structure: {wall_id: {"manual": bool, "current_speed": int}}
+_override_snapshot: Optional[Dict[int, Dict]] = None
+
+logger = logging.getLogger("foundry_logger")
+
+_API_KEY_HEADER = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def _require_api_key(api_key: Optional[str] = Depends(_API_KEY_HEADER)) -> None:
+    """FastAPI dependency: validates the X-API-Key header."""
+    if not api_key_manager.list_keys():
+        raise HTTPException(
+            status_code=503,
+            detail="API access is not enabled on this server (no API keys configured).",
+        )
+
+    if not api_key or not api_key_manager.validate_key(api_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key.")
+
+
+def _serialize_powerboard(location: int):
+    """Return a dict of metrics for a single powerboard by location."""
+    pb_dict = globals.powerboardDict or {}
+    pb = pb_dict.get(location)
+    if pb is None:
+        return None
+
+    # PWM percentages are always available after init
+    pwm = pb.get_fan_pwm()
+
+    # RPM and wattage may be unavailable if the first poll hasn't completed
+    try:
+        rpm = pb.get_fan_tach()
+    except PowerboardError:
+        rpm = (None, None, None)
+
+    try:
+        wattage = pb.get_power_usage()
+    except PowerboardError:
+        wattage = (None, None, None, None)
+
+    total_watts = (
+        sum(w for w in wattage if w is not None) if any(w is not None for w in wattage) else None
+    )
+
+    return {
+        "location": location,
+        "hardware_revision": pb.hardware_revision,
+        "firmware_version": pb.firmware_version,
+        "is_connected": pb.is_connected,
+        "fan": {
+            "pwm_percent": {
+                "row1": pwm[0],
+                "row2": pwm[1],
+                "row3": pwm[2],
+            },
+            "rpm": {
+                "row1": rpm[0],
+                "row2": rpm[1],
+                "row3": rpm[2],
+            },
+        },
+        "power": {
+            "shunt1_watts": float(wattage[0]) if wattage[0] is not None else None,
+            "shunt2_watts": float(wattage[1]) if wattage[1] is not None else None,
+            "shunt3_watts": float(wattage[2]) if wattage[2] is not None else None,
+            "shunt4_watts": float(wattage[3]) if wattage[3] is not None else None,
+            "section_1_2_watts": pb.watt_sec_1_2,
+            "section_3_4_watts": pb.watt_sec_3_4,
+            "total_watts": int(total_watts) if total_watts is not None else None,
+        },
+    }
+
+
+@app.get("/api/v1/status", tags=["api"])
+async def api_status(_: None = Depends(_require_api_key)):
+    """Return service health and how many powerboards are connected."""
+    pb_dict = globals.powerboardDict or {}
+    return {
+        "status": "ok",
+        "powerboards_connected": len(pb_dict),
+        "powerboard_locations": sorted(pb_dict.keys()),
+    }
+
+
+@app.get("/api/v1/powerboards", tags=["api"])
+async def get_all_powerboards(_: None = Depends(_require_api_key)):
+    """Return metrics for every connected powerboard."""
+    pb_dict = globals.powerboardDict or {}
+    boards = []
+    for location in sorted(pb_dict.keys()):
+        data = _serialize_powerboard(location)
+        if data is not None:
+            boards.append(data)
+    return {"powerboards": boards}
+
+
+@app.get("/api/v1/powerboards/{location}", tags=["api"])
+async def get_powerboard(location: int, _: None = Depends(_require_api_key)):
+    """Return metrics for a single powerboard by its location index (1 or 2)."""
+    pb_dict = globals.powerboardDict or {}
+    if location not in pb_dict:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Powerboard at location {location} not found. "
+                   f"Connected locations: {sorted(pb_dict.keys())}",
+        )
+    return _serialize_powerboard(location)
+
+# Reverse alias map for serializing wall IDs back to friendly names
+_WALL_ID_TO_KEY = {v: k for k, v in _WALL_ALIAS.items()}  # {4: "aux1", 5: "aux2", 6: "aux3"}
+
+
+def _serialize_fan_wall(wall_id: int):
+    """Return a status dict for a single fan wall."""
+    svc = globals.fan_control_service
+    if svc is None:
+        return None
+
+    wall = svc.fan_walls.get(wall_id)
+    if wall is None:
+        return None
+
+    # Look up RPM from the powerboard using the wall's header assignment
+    rpm = None
+    pb_dict = globals.powerboardDict or {}
+    if wall.powerboard_id is not None and wall.header_index is not None:
+        pb = pb_dict.get(wall.powerboard_id)
+        if pb is not None and pb._current_fan_rpm is not None:
+            rpm = pb._current_fan_rpm[wall.header_index]
+
+    return {
+        "wall_id": wall_id,
+        "key": _WALL_ID_TO_KEY.get(wall_id, str(wall_id)),
+        "name": wall.name,
+        "pwm_percent": wall.current_speed,
+        "rpm": rpm,
+        "manual": wall.manual,
+        "assigned_profile": wall.assigned_profile,
+        "override_active": _override_snapshot is not None and wall_id in _override_snapshot,
+        "powerboard_id": wall.powerboard_id,
+        "header_index": wall.header_index,
+    }
+
+
+@app.get("/api/v1/fans/status", tags=["fans"])
+async def get_fans_status(_: None = Depends(_require_api_key)):
+    """Return PWM, RPM, and override state for all fan walls."""
+    svc = globals.fan_control_service
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Fan control service not available.")
+
+    return {
+        "override_active": _override_snapshot is not None,
+        "walls": [_serialize_fan_wall(wid) for wid in sorted(svc.fan_walls.keys())],
+    }
+
+
+@app.get("/api/v1/fans/status/{wall_key}", tags=["fans"])
+async def get_fan_wall_status(wall_key: str, _: None = Depends(_require_api_key)):
+    """Return PWM, RPM, and override state for a single fan wall (1, 2, 3, aux1, aux2, or aux3)."""
+    svc = globals.fan_control_service
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Fan control service not available.")
+
+    try:
+        wall_id = _resolve_wall_key(wall_key)
+    except (ValueError, KeyError):
+        raise HTTPException(status_code=422, detail=f"Unknown wall identifier: '{wall_key}'")
+
+    data = _serialize_fan_wall(wall_id)
+    if data is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Fan wall '{wall_key}' not found. "
+                   f"Available: {[_WALL_ID_TO_KEY.get(w, str(w)) for w in sorted(svc.fan_walls.keys())]}",
+        )
+    return data
+
+
+class OverrideRequest(BaseModel):
+    active: bool
+    pwm_percent: Optional[int] = None   # global default for all walls (0-100)
+    walls: Optional[Dict[str, int]] = None  # per-wall overrides: "1"/"2"/"3"/"4"/"5"/"6"/"aux1"/"aux2"/"aux3" -> 0-100
+
+    @field_validator("pwm_percent")
+    @classmethod
+    def _check_global_pwm(cls, v):
+        if v is not None and not (0 <= v <= 100):
+            raise ValueError("pwm_percent must be between 0 and 100")
+        return v
+
+    @field_validator("walls")
+    @classmethod
+    def _check_wall_pwm(cls, v):
+        if v is None:
+            return v
+        for key, speed in v.items():
+            resolved = _WALL_ALIAS.get(key, None)
+            try:
+                wall_id = resolved if resolved is not None else int(key)
+            except ValueError:
+                raise ValueError(f"Unknown wall identifier: '{key}'")
+            if not (0 <= speed <= 100):
+                raise ValueError(f"Speed for wall '{key}' must be between 0 and 100")
+        return v
+
+
+def _resolve_wall_key(key: str) -> int:
+    """Convert a wall key string ('1', '2', '3', 'aux1', 'aux2', 'aux3') to an int wall ID."""
+    if key in _WALL_ALIAS:
+        return _WALL_ALIAS[key]
+    try:
+        return int(key)
+    except ValueError:
+        raise ValueError(f"Unknown wall identifier: '{key}'")
+
+
+@app.post("/api/v1/fans/override", tags=["fans"])
+async def fan_override(request: OverrideRequest, _: None = Depends(_require_api_key)):
+    """
+    Engage or release a temporary fan speed override.
+
+    - active=true: force all (or specific) walls to manual mode at the given speed.
+      The first call snapshots current wall state; subsequent calls with active=true
+      only update speeds without altering the snapshot.
+    - active=false: restore every wall to its pre-override state and clear the snapshot.
+
+    Wall keys: "1", "2", "3" (main walls), "4"/"aux1", "5"/"aux2", "6"/"aux3" (auxiliary walls).
+    Per-wall speeds in `walls` take precedence over the global `pwm_percent`.
+    """
+    global _override_snapshot
+
+    svc = globals.fan_control_service
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Fan control service not available.")
+
+    if not request.active:
+        if _override_snapshot is None:
+            return {"override_active": False, "detail": "No active override to release."}
+
+        pb_dict = globals.powerboardDict or {}
+        pb_updates: Dict[int, dict] = {}
+
+        for wall_id, saved in _override_snapshot.items():
+            wall = svc.fan_walls.get(wall_id)
+            if wall is None:
+                continue
+            wall.manual = saved["manual"]
+            wall.current_speed = saved["current_speed"]
+
+            pb_id = saved["powerboard_id"]
+            h_idx = saved["header_index"]
+            pb = pb_dict.get(pb_id) if pb_id is not None else None
+            if pb is not None and h_idx is not None:
+                if pb_id not in pb_updates:
+                    pb_updates[pb_id] = {"pb": pb, "speeds": list(pb.get_running_fan_pwm())}
+                pb_updates[pb_id]["speeds"][h_idx] = saved["current_speed"]
+
+        for entry in pb_updates.values():
+            pb_obj = entry["pb"]
+            speeds = entry["speeds"]
+            pb_obj.set_running_fan_pwm(*speeds)
+            await run.io_bound(pb_obj.update_fan_speed, *speeds)
+
+        _override_snapshot = None
+        return {"override_active": False, "detail": "Override released. Wall states restored."}
+
+    if request.pwm_percent is None and not request.walls:
+        raise HTTPException(
+            status_code=422,
+            detail="Provide pwm_percent, walls, or both when active=true.",
+        )
+
+    # Resolve per-wall targets and validate all wall IDs exist
+    per_wall: Dict[int, int] = {}
+    if request.walls:
+        for key, speed in request.walls.items():
+            wall_id = _resolve_wall_key(key)
+            if wall_id not in svc.fan_walls:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"Unknown wall ID '{key}'. Available: {[_WALL_ID_TO_KEY.get(w, str(w)) for w in sorted(svc.fan_walls.keys())]}",
+                )
+            per_wall[wall_id] = speed
+
+    # Snapshot on first engagement only
+    was_new = _override_snapshot is None
+    if was_new:
+        _override_snapshot = {
+            wall_id: {
+                "manual": wall.manual,
+                "current_speed": wall.current_speed,
+                "powerboard_id": wall.powerboard_id,
+                "header_index": wall.header_index,
+            }
+            for wall_id, wall in svc.fan_walls.items()
+        }
+
+    applied: Dict[str, int] = {}
+    skipped: list = []
+    pb_dict = globals.powerboardDict or {}
+    pb_updates: Dict[int, dict] = {}
+
+    for wall_id, wall in svc.fan_walls.items():
+        # Determine target speed: per-wall entry wins, then global default
+        if wall_id in per_wall:
+            target = per_wall[wall_id]
+        elif request.pwm_percent is not None:
+            target = request.pwm_percent
+        else:
+            # Not covered by this request — leave untouched
+            continue
+
+        # Skip walls with no hardware assignment — nothing to drive
+        if wall.powerboard_id is None or wall.header_index is None:
+            skipped.append({"wall": wall.name, "reason": "no hardware assignment"})
+            continue
+
+        wall.manual = True
+        wall.current_speed = target
+        applied[wall.name] = target
+
+        pb = pb_dict.get(wall.powerboard_id)
+        if pb is not None:
+            if wall.powerboard_id not in pb_updates:
+                pb_updates[wall.powerboard_id] = {"pb": pb, "speeds": list(pb.get_running_fan_pwm())}
+            pb_updates[wall.powerboard_id]["speeds"][wall.header_index] = target
+
+    for entry in pb_updates.values():
+        pb_obj = entry["pb"]
+        speeds = entry["speeds"]
+        pb_obj.set_running_fan_pwm(*speeds)
+        await run.io_bound(pb_obj.update_fan_speed, *speeds)
+
+    return {
+        "override_active": True,
+        "applied": applied,
+        "skipped": skipped,
+        "snapshot_taken": was_new,
+    }

--- a/api_key_manager.py
+++ b/api_key_manager.py
@@ -1,0 +1,115 @@
+"""
+API key management for Hako Foundry.
+
+Keys are stored as SHA-256 hashes in config/api_config.json.
+The raw key is returned only once at creation time and never persisted.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import secrets
+import stat
+import time
+import uuid
+from typing import Optional
+
+API_CONFIG_FILE = "config/api_config.json"
+logger = logging.getLogger("foundry_logger")
+
+
+class ApiKeyManager:
+    def __init__(self):
+        self._ensure_config_dir()
+        self._cache: Optional[dict] = None
+
+    def _ensure_config_dir(self):
+        """Ensure the config directory exists before any read/write."""
+        config_dir = os.path.dirname(API_CONFIG_FILE)
+        if not os.path.exists(config_dir):
+            os.makedirs(config_dir)
+
+    def _load_config(self) -> dict:
+        """Load key config from disk (cached after first read)."""
+        if self._cache is not None:
+            return self._cache
+        try:
+            if os.path.exists(API_CONFIG_FILE):
+                with open(API_CONFIG_FILE, "r") as f:
+                    self._cache = json.load(f)
+                    return self._cache
+        except Exception as e:
+            logger.error(f"Error loading API key config: {e}")
+        self._cache = {"keys": []}
+        return self._cache
+
+    def _save_config(self, config: dict):
+        """Persist key config to disk with owner-only (600) permissions, and update cache."""
+        try:
+            with open(API_CONFIG_FILE, "w") as f:
+                json.dump(config, f, indent=4)
+            try:
+                os.chmod(API_CONFIG_FILE, stat.S_IRUSR | stat.S_IWUSR)
+            except OSError as e:
+                logger.warning(f"Could not set permissions on API key config: {e}")
+            self._cache = config
+        except Exception as e:
+            logger.error(f"Error saving API key config: {e}")
+
+    @staticmethod
+    def _hash(key: str) -> str:
+        """Return the SHA-256 hex digest of a key."""
+        return hashlib.sha256(key.encode()).hexdigest()
+
+    def list_keys(self) -> list:
+        """Return key metadata (id, name, prefix, created_at) — no secrets."""
+        return [
+            {
+                "id": k["id"],
+                "name": k["name"],
+                "prefix": k["prefix"],
+                "created_at": k["created_at"],
+            }
+            for k in self._load_config().get("keys", [])
+        ]
+
+    def create_key(self, name: str) -> str:
+        """Generate, store, and return a new API key. Shown to the user exactly once."""
+        raw = "hf-api_" + secrets.token_urlsafe(32)
+        new_entry = {
+            "id": str(uuid.uuid4()),
+            "name": name,
+            "prefix": raw[:12],  # "hf-api_XXXXX" — enough for identification
+            "hash": self._hash(raw),
+            "created_at": time.time(),
+        }
+        new_config = {"keys": self._load_config().get("keys", []) + [new_entry]}
+        self._save_config(new_config)
+        logger.info(f"API key created: '{name}'")
+        return raw
+
+    def delete_key(self, key_id: str) -> bool:
+        """Remove a key by id. Returns True if a key was removed, False if not found."""
+        existing = self._load_config().get("keys", [])
+        new_keys = [k for k in existing if k["id"] != key_id]
+        if len(new_keys) == len(existing):
+            return False
+        self._save_config({"keys": new_keys})
+        logger.info(f"API key deleted: {key_id}")
+        return True
+
+    def validate_key(self, key: str) -> bool:
+        """Return True if the key matches any stored key (timing-safe, no early exit)."""
+        if not key:
+            return False
+        key_hash = self._hash(key)
+        matched = False
+        for k in self._load_config().get("keys", []):
+            stored = k.get("hash", "")
+            if stored and secrets.compare_digest(key_hash, stored):
+                matched = True
+        return matched
+
+
+api_key_manager = ApiKeyManager()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import all_pages
+import api  # noqa: F401 – registers API routes with the NiceGUI/FastAPI app
 import authentication
 import globals
 import os

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -1,7 +1,11 @@
+import json
+import time
+
 from nicegui import ui
 from authentication import require_auth
 import globals
 import page_layout
+from api_key_manager import api_key_manager
 
 @require_auth
 def settingsPage():
@@ -250,6 +254,96 @@ def settingsPage():
                     on_click=apply_pwm_settings
                 ).classes('border-solid border-2 border-[#ffdd00] text-white px-6 py-2').props('flat')
 
+    def create_api_keys_section():
+        """Create API key management UI."""
+        state = {'pending_delete_id': None, 'generated_key': ''}
+
+        @ui.refreshable
+        def api_keys_list():
+            keys = api_key_manager.list_keys()
+            if not keys:
+                ui.label('No API keys configured.').classes('text-gray-500 italic text-sm')
+                return
+            with ui.column().classes('w-full gap-2'):
+                for key in keys:
+                    created = time.strftime('%Y-%m-%d', time.localtime(key['created_at']))
+                    with ui.row().classes('w-full items-center justify-between'):
+                        with ui.column().classes('gap-0'):
+                            ui.label(key['name']).classes('font-medium text-sm')
+                            ui.label(f"{key['prefix']}...  •  Created {created}").classes('text-xs text-gray-500 font-mono')
+                        ui.button(
+                            icon='delete',
+                            on_click=lambda _, kid=key['id'], kname=key['name']: open_delete_dialog(kid, kname)
+                        ).props('flat color=red dense')
+
+        with ui.dialog().props('persistent') as create_dialog, ui.card().classes('p-6 min-w-80'):
+            ui.label('Generate New API Key').classes('text-lg font-bold mb-4')
+            name_input = ui.input('Key Name', placeholder='e.g. Home Assistant').classes('w-full mb-2')
+            create_error = ui.label('').classes('text-red-500 text-sm mb-2')
+            create_error.visible = False
+
+            def do_create():
+                name = name_input.value.strip()
+                if not name:
+                    create_error.text = 'Key name is required'
+                    create_error.visible = True
+                    return
+                state['generated_key'] = api_key_manager.create_key(name)
+                name_input.value = ''
+                create_error.visible = False
+                create_dialog.close()
+                key_display_label.set_text(state['generated_key'])
+                show_key_dialog.open()
+                api_keys_list.refresh()
+
+            def cancel_create():
+                name_input.value = ''
+                create_error.visible = False
+                create_dialog.close()
+
+            with ui.row().classes('w-full justify-end gap-2 mt-2'):
+                ui.button('Cancel', on_click=cancel_create).props('flat color=white')
+                ui.button('Generate', on_click=do_create).classes('border-solid border-2 border-[#ffdd00]').props('flat color=white')
+
+        with ui.dialog().props('persistent') as show_key_dialog, ui.card().classes('p-6 min-w-96'):
+            ui.label('API Key Generated').classes('text-lg font-bold mb-2')
+            ui.label('Copy this key now — it will not be shown again.').classes('text-sm text-amber-400 mb-4')
+            key_display_label = ui.label('').classes('font-mono text-sm bg-gray-800 p-3 rounded w-full break-all select-all')
+
+            async def copy_key():
+                await ui.run_javascript(f'navigator.clipboard.writeText({json.dumps(state["generated_key"])})')
+                ui.notify('Key copied to clipboard', position='bottom-right', type='positive', group=False)
+
+            with ui.row().classes('w-full justify-end gap-2 mt-4'):
+                ui.button('Copy', icon='content_copy', on_click=copy_key).classes('border-solid border-2 border-[#ffdd00]').props('flat color=white')
+                ui.button('Done', on_click=show_key_dialog.close).props('flat color=white')
+
+        with ui.dialog().props('persistent') as delete_dialog, ui.card().classes('p-6'):
+            ui.label('Delete API Key?').classes('text-lg font-bold mb-2')
+            delete_name_label = ui.label('').classes('text-sm text-gray-400 mb-2')
+            ui.label('This immediately invalidates the key.').classes('text-sm text-gray-500 mb-4')
+
+            def do_delete():
+                if state['pending_delete_id']:
+                    api_key_manager.delete_key(state['pending_delete_id'])
+                    state['pending_delete_id'] = None
+                    delete_dialog.close()
+                    api_keys_list.refresh()
+                    ui.notify('API key deleted', position='bottom-right', type='positive', group=False)
+
+            with ui.row().classes('w-full justify-end gap-2'):
+                ui.button('Cancel', on_click=delete_dialog.close).props('flat color=white')
+                ui.button('Delete', on_click=do_delete).classes('border-solid border-2 border-red-500').props('flat color=red')
+
+        def open_delete_dialog(key_id: str, key_name: str):
+            state['pending_delete_id'] = key_id
+            delete_name_label.set_text(f'Key: {key_name}')
+            delete_dialog.open()
+
+        api_keys_list()
+        with ui.row().classes('w-full mt-4'):
+            ui.button('Generate New API Key', icon='add', on_click=create_dialog.open).classes('border-solid border-2 border-[#ffdd00]').props('flat color=white')
+
     # Main settings UI
     with page_layout.frame('Settings'):
         with ui.element('div').classes('flex w-full').style('justify-content: safe center;'):
@@ -283,7 +377,7 @@ def settingsPage():
                     current_unit = globals.layoutState.get_units()
                     # Find the display name for the current value
                     current_display = next((k for k, v in unit_options.items() if v == current_unit), 'Celsius (C°)')
-                    
+
                     ui.select(
                         list(unit_options.keys()),
                         value=current_display,
@@ -339,6 +433,14 @@ def settingsPage():
                     ui.label('Default Fan Speed').classes('text-xl font-bold mb-4')
                     ui.label('These will be used when the system starts and persist between power cycles.').classes('text-sm text-gray-500 mb-2')
                     create_pwm_settings()
+
+                ui.separator().classes('mb-6')
+
+                # API Keys Section
+                with ui.column().classes('w-full'):
+                    ui.label('API Keys').classes('text-xl font-bold mb-2')
+                    ui.label('Keys are stored as hashes in config/api_config.json. Each key is shown only once at creation.').classes('text-sm text-gray-500 mb-4')
+                    create_api_keys_section()
 
                 # Additional spacing
                 ui.space().classes('h-2')


### PR DESCRIPTION
Adds a REST API to Hako Foundry for monitoring powerboards and controlling fan speeds over HTTP. Endpoints cover service health, powerboard metrics, fan wall status, and a temporary fan speed override that snapshots wall state on engagement and restores it on release. Authentication is handled via an X-API-Key header; keys are generated in the Settings page and stored as SHA-256 hashes. See API.md for full endpoint documentation.