### PR TITLE
feat: dynamic fan wall assignment and 4-row DAS support

### DIFF
--- a/fan_control_service.py
+++ b/fan_control_service.py
@@ -31,13 +31,19 @@ except ImportError:
 class FanWall:
     """Represents a single fan wall that can be controlled by a fan profile."""
     
-    def __init__(self, wall_id: int, name: str = None, assigned_profile: Optional[str] = None):
+    def __init__(self, wall_id: int, name: str = None, assigned_profile: Optional[str] = None,
+             powerboard_id: Optional[int] = None, header_index: Optional[int] = None):
         self.wall_id = wall_id
-        self.name = name        
+        self.name = name
         self.assigned_profile = assigned_profile # Profile name
         self.current_speed = 0  # Current fan speed percentage (0-100)
         self.manual: bool = True  # True for manual control, False for profile control
         self._service_ref = None  # Reference to the service for triggering saves
+        self.powerboard_id: Optional[int] = powerboard_id    # which powerboard (1, 2, ...)
+        self.header_index: Optional[int] = header_index      # 0=Row1, 1=Row2, 2=Row3
+        self.watt_label: Optional[str] = None                # Custom wattage label; None = auto-derive
+        self.watt_powerboard_id: Optional[int] = None        # Powerboard for wattage reading (independent of fan control)
+        self.watt_attr: Optional[str] = None                 # 'watt_sec_1_2' (J1) or 'watt_sec_3_4' (J2)
     
     def set_service_reference(self, service):
         """Set reference to the fan control service for triggering config saves."""
@@ -123,6 +129,11 @@ class FanControlService:
                 wall = self.fan_walls[wall_id]
                 wall.assigned_profile = wall_config.get('assigned_profile', wall.assigned_profile)
                 wall.manual = wall_config.get('manual', True)
+                wall.powerboard_id = wall_config.get('powerboard_id', wall.powerboard_id)
+                wall.header_index = wall_config.get('header_index', wall.header_index)
+                wall.watt_label = wall_config.get('watt_label', None)
+                wall.watt_powerboard_id = wall_config.get('watt_powerboard_id', None)
+                wall.watt_attr = wall_config.get('watt_attr', None)
                 # Don't override current_speed from powerboard readings
                 logger.info(f"Applied config to {wall.name}: Profile={wall.assigned_profile}, Manual={wall.manual}")
         
@@ -153,7 +164,12 @@ class FanControlService:
                     'name': wall.name,
                     'assigned_profile': wall.assigned_profile,
                     'manual': wall.manual,
-                    'current_speed': wall.current_speed
+                    'current_speed': wall.current_speed,
+                    'powerboard_id': wall.powerboard_id,
+                    'header_index': wall.header_index,
+                    'watt_label': wall.watt_label,
+                    'watt_powerboard_id': wall.watt_powerboard_id,
+                    'watt_attr': wall.watt_attr,
                 }
             
             logger.debug(f"Config data prepared: {len(config['fan_walls'])} fan walls")
@@ -205,35 +221,38 @@ class FanControlService:
         return True
         
     def fan_speed_current(self, pb) -> bool:
-        """Check if the fan wall service and up to date."""
+        """Check if hardware fan speeds match current wall speeds for a given powerboard."""
         import globals
-        # Check first powerboard
-        if pb == 1:
-            current_fan_speeds = (self.fan_walls[1].current_speed, \
-                                self.fan_walls[2].current_speed, \
-                                self.fan_walls[3].current_speed)
-            if current_fan_speeds != globals.powerboardDict[1].get_running_fan_pwm():
-                return False
-        # Check second powerboard
-        if pb == 2:
-            current_aux_speed = self.fan_walls[4].current_speed
-            if current_aux_speed != globals.powerboardDict[2].get_running_fan_pwm()[2]:
-                return False
-
+        if pb not in globals.powerboardDict:
+            return True
+        pb_obj = globals.powerboardDict[pb]
+        running = pb_obj.get_running_fan_pwm()
+        for wall in self.fan_walls.values():
+            if wall.powerboard_id == pb_obj.location and wall.header_index is not None:
+                if wall.current_speed != running[wall.header_index]:
+                    return False
         return True
     def update_powerboard_fan_speed(self, pb) -> None:
-        """Update the fan speed on the powerboard."""
-
+        """Update hardware fan speed for a given powerboard using current wall assignments."""
         import globals
-        if pb == 1:
-            current_fan_speeds = (self.fan_walls[1].current_speed, \
-                                 self.fan_walls[2].current_speed, \
-                                 self.fan_walls[3].current_speed)
-            globals.powerboardDict[1].update_fan_speed(current_fan_speeds[0], current_fan_speeds[1], current_fan_speeds[2])
+        if pb not in globals.powerboardDict:
+            return
+        pb_obj = globals.powerboardDict[pb]
+        speeds = list(pb_obj.get_running_fan_pwm())
+        for wall in self.fan_walls.values():
+            if wall.powerboard_id == pb_obj.location and wall.header_index is not None:
+                speeds[wall.header_index] = wall.current_speed
+        pb_obj.update_fan_speed(*speeds)
 
-        if pb == 2:
-            current_aux_speed = self.fan_walls[4].current_speed
-            globals.powerboardDict[2].update_fan_speed(current_aux_speed, current_aux_speed, current_aux_speed)
+    def _pb_for_location(self, location: Optional[int]):
+        """Return the Powerboard whose V: location matches, or None."""
+        if location is None:
+            return None
+        import globals
+        for pb in globals.powerboardDict.values():
+            if pb.location == location:
+                return pb
+        return None
 
     def _initialize_fan_walls(self):
         """Initialize fan walls based on powerboard availability."""
@@ -243,25 +262,35 @@ class FanControlService:
         
         # Initialize main fan walls if powerboard 1 is available
         if 1 in globals.powerboardDict:
-            pb1_queued_fan_speed = globals.powerboardDict[1].get_running_fan_pwm()
+            pb1 = globals.powerboardDict[1]
+            pb1_queued_fan_speed = pb1.get_running_fan_pwm()
             for i in range(1, 4):
                 wall_name = f"Fan Wall {i}"
-                # Create wall with default values, config will be applied later if it exists
-                self.fan_walls[i] = FanWall(i, wall_name, default_profile)
-                self.fan_walls[i].set_service_reference(self)  # Set service reference
+                self.fan_walls[i] = FanWall(i, wall_name, default_profile, powerboard_id=pb1.location, header_index=i - 1)
+                self.fan_walls[i].set_service_reference(self)
                 self.fan_walls[i].current_speed = pb1_queued_fan_speed[i - 1]
                 logger.info(f"Initialized {wall_name}")
             app.timer(3.0, self.ping_powerboards)
 
-        # Initialize auxiliary fan wall if powerboard 2 is available
+        # Always initialize Auxiliary Fan 1; assign to powerboard 2 if available
+        self.fan_walls[4] = FanWall(4, "Auxiliary Fan 1", default_profile)
+        self.fan_walls[4].set_service_reference(self)
         if 2 in globals.powerboardDict:
-            pb2_queued_fan_speed = globals.powerboardDict[2].get_running_fan_pwm()
-            self.fan_walls[4] = FanWall(4, "Auxiliary Fan Wall", default_profile)
-            self.fan_walls[4].set_service_reference(self)  # Set service reference
-            self.fan_walls[4].current_speed = pb2_queued_fan_speed[2]  # Use third speed for auxiliary wall
-            
-            logger.info("Initialized Auxiliary Fan Wall")
-        
+            pb2 = globals.powerboardDict[2]
+            pb2_queued_fan_speed = pb2.get_running_fan_pwm()
+            self.fan_walls[4].powerboard_id = pb2.location
+            self.fan_walls[4].header_index = 2
+            self.fan_walls[4].current_speed = pb2_queued_fan_speed[2]
+            logger.info("Initialized Auxiliary Fan 1 (assigned to PB2)")
+        else:
+            logger.info("Initialized Auxiliary Fan 1 (unassigned)")
+
+        # Initialize unassigned auxiliary fans 2 and 3
+        for zone_id, zone_name in [(5, "Auxiliary Fan 2"), (6, "Auxiliary Fan 3")]:
+            self.fan_walls[zone_id] = FanWall(zone_id, zone_name, default_profile)
+            self.fan_walls[zone_id].set_service_reference(self)
+            logger.info(f"Initialized {zone_name} (unassigned)")
+
         # Apply loaded configuration after wall initialization
         self._apply_loaded_config()
     
@@ -306,6 +335,37 @@ class FanControlService:
         
         return True
     
+    def set_wall_assignment(self, wall_id: int, powerboard_id: Optional[int], header_index: Optional[int]) -> bool:
+        """Assign a fan wall to a powerboard (by location) and header. Enforces uniqueness."""
+        if wall_id not in self.fan_walls:
+            return False
+
+        # Uniqueness check: no other wall may share the same (location, header)
+        if powerboard_id is not None and header_index is not None:
+            for wid, wall in self.fan_walls.items():
+                if wid == wall_id:
+                    continue
+                if wall.powerboard_id == powerboard_id and wall.header_index == header_index:
+                    logger.warning(
+                        f"Assignment conflict: Wall {wid} already uses PB location {powerboard_id} Row {header_index + 1}"
+                    )
+                    return False
+
+        self.fan_walls[wall_id].powerboard_id = powerboard_id
+        self.fan_walls[wall_id].header_index = header_index
+        self.save_config_immediate()
+        logger.info(f"Wall {wall_id} assigned to PB location {powerboard_id} Row {header_index + 1 if header_index is not None else '-'}")
+        return True
+
+    def set_wall_wattage_source(self, wall_id: int, powerboard_id: Optional[int], watt_attr: Optional[str]) -> None:
+        """Set the independent wattage source (powerboard + connector) for a wall's display row."""
+        if wall_id not in self.fan_walls:
+            return
+        self.fan_walls[wall_id].watt_powerboard_id = powerboard_id
+        self.fan_walls[wall_id].watt_attr = watt_attr
+        self.save_config_immediate()
+        logger.info(f"Wall {wall_id} wattage source set to PB{powerboard_id}:{watt_attr}")
+
     def set_manual_mode(self, wall_id: int, manual: bool = True) -> bool:
         """Set manual mode for a specific fan wall."""
         if wall_id not in self.fan_walls:
@@ -437,77 +497,44 @@ class FanControlService:
         """Perform automatic fan speed update based on fan profiles."""
         if not self.automatic_control_enabled or not self.fan_wall_service_active:
             return
-        
+
         try:
-            # Calculate new speeds for automatic walls
-            new_speeds = [None, None, None]  # For walls 1, 2, 3
-            any_automatic_walls = False
-            
+            import globals
+            pb_speeds: Dict[int, list] = {}
+            changed_walls = []
+
             for wall_id in [1, 2, 3]:
                 wall = self.fan_walls.get(wall_id)
-                if wall and not wall.manual and wall.assigned_profile:
-                    speed = self._update_single_fan_wall(wall_id)
-                    if speed is not None:
-                        new_speeds[wall_id - 1] = round(speed)
-                        any_automatic_walls = True
-            
-            # If we have automatic walls, update the hardware
-            if any_automatic_walls:
-                await self._request_update_fan_speed_direct(new_speeds)
-                
+                if not wall or wall.manual or not wall.assigned_profile:
+                    continue
+                if wall.powerboard_id is None:
+                    continue
+
+                speed = self._update_single_fan_wall(wall_id)
+                if speed is not None:
+                    loc = wall.powerboard_id
+                    pb_obj = self._pb_for_location(loc)
+                    if pb_obj is None:
+                        continue
+                    if loc not in pb_speeds:
+                        pb_speeds[loc] = {'pb': pb_obj, 'speeds': list(pb_obj.get_running_fan_pwm())}
+                    pb_speeds[loc]['speeds'][wall.header_index] = round(speed)
+                    changed_walls.append(f"Wall {wall_id}")
+
+            for entry in pb_speeds.values():
+                pb_obj = entry['pb']
+                speeds = entry['speeds']
+                pb_obj.set_running_fan_pwm(*speeds)
+                await run.io_bound(pb_obj.update_fan_speed, *speeds)
+
+            if changed_walls:
+                ui.notify(
+                    f"🤖 Auto: {', '.join(changed_walls)} updated",
+                    position='bottom-right', type='info', group=False, timeout=1000
+                )
+
         except Exception as e:
             logger.error(f"Error in automatic fan control update: {e}")
-    
-    async def _request_update_fan_speed_direct(self, speeds: List[Optional[float]]):
-        """Request fan speed update with direct speed values instead of sliders."""
-        # Skip if we're updating sliders programmatically to prevent feedback loops
-        if self.updating_sliders_programmatically:
-            return
-        
-        acquired = self.update_pwm_semaphore.acquire(blocking=False)
-        if acquired:
-            try:
-                import globals
-                if 1 in globals.powerboardDict:
-                    await run.io_bound(globals.powerboardDict[1].semaphore.acquire)
-                    globals.powerboardDict[1].semaphore.release()  # Wait for semaphore before grabbing new values
-                    
-                    # Get current running speeds and update only automatic ones
-                    current_pwm = globals.powerboardDict[1].get_running_fan_pwm()
-                    row0_pwm = speeds[0] if speeds[0] is not None else current_pwm[0]
-                    row1_pwm = speeds[1] if speeds[1] is not None else current_pwm[1]
-                    row2_pwm = speeds[2] if speeds[2] is not None else current_pwm[2]
-                    
-                    # Set the running PWM values
-                    globals.powerboardDict[1].set_running_fan_pwm(row0_pwm, row1_pwm, row2_pwm)
-                    
-                    # Update the powerboard with the latest values
-                    await run.io_bound(
-                        globals.powerboardDict[1].update_fan_speed, 
-                        row0_pwm, 
-                        row1_pwm, 
-                        row2_pwm
-                    )
-                    
-                    # Only show notification if speeds actually changed
-                    changed_walls = []
-                    if speeds[0] is not None: changed_walls.append("Wall 1")
-                    if speeds[1] is not None: changed_walls.append("Wall 2") 
-                    if speeds[2] is not None: changed_walls.append("Wall 3")
-                    
-                    if changed_walls:
-                        ui.notify(
-                            f"🤖 Auto: {', '.join(changed_walls)} updated",
-                            position='bottom-right', 
-                            type='info', 
-                            group=False,
-                            timeout=1000  # Shorter timeout for auto updates
-                        )
-                        
-            except Exception as e:
-                logger.error(f"Error in automatic fan speed update: {e}")
-            finally:
-                self.update_pwm_semaphore.release()
     
     def get_fan_wall_status(self, wall_id: int) -> Optional[Dict[str, Any]]:
         """Get status of a specific fan wall."""
@@ -541,43 +568,41 @@ class FanControlService:
         return slider_list[3].value if len(slider_list) > 3 and slider_list[3] else 0
     
     async def request_update_fan_speed(self, slider_list: List):
-        """Request fan speed update with semaphore protection."""
-        # Skip if we're updating sliders programmatically to prevent feedback loops
+        """Request fan speed update for walls 1–3 using their current PB/header assignments."""
         if self.updating_sliders_programmatically:
             return
-            
-        # Get the current slider values right when semaphore becomes available
-        def get_current_values():
-            return self.get_current_slider_values(slider_list)
-        
+
         acquired = self.update_pwm_semaphore.acquire(blocking=False)
         if acquired:
             try:
                 import globals
-                if 1 in globals.powerboardDict:
-                    await run.io_bound(globals.powerboardDict[1].semaphore.acquire)
-                    globals.powerboardDict[1].semaphore.release()  # Wait for semaphore before grabbing new values
-                    
-                    # Get the latest values right here when semaphore is available
-                    row0_pwm, row1_pwm, row2_pwm = get_current_values()
-                    
-                    # Set the running PWM values
-                    globals.powerboardDict[1].set_running_fan_pwm(row0_pwm, row1_pwm, row2_pwm)
-                    
+                # Build per-PB speed maps from walls 1/2/3
+                pb_speeds: Dict[int, list] = {}
+                for wall_id, slider_idx in ((1, 0), (2, 1), (3, 2)):
+                    wall = self.fan_walls.get(wall_id)
+                    if not wall or wall.powerboard_id is None or wall.header_index is None:
+                        continue
+                    if slider_idx >= len(slider_list) or slider_list[slider_idx] is None:
+                        continue
+                    loc = wall.powerboard_id
+                    pb_obj = self._pb_for_location(loc)
+                    if pb_obj is None:
+                        continue
+                    if loc not in pb_speeds:
+                        pb_speeds[loc] = {'pb': pb_obj, 'speeds': list(pb_obj.get_running_fan_pwm())}
+                    pb_speeds[loc]['speeds'][wall.header_index] = slider_list[slider_idx].value
+
+                for loc, entry in pb_speeds.items():
+                    pb_obj = entry['pb']
+                    speeds = entry['speeds']
+                    await run.io_bound(pb_obj.semaphore.acquire)
+                    pb_obj.semaphore.release()
+                    pb_obj.set_running_fan_pwm(*speeds)
                     ui.notify(
-                        f"PWM updated {row0_pwm}, {row1_pwm}, {row2_pwm}",
-                        position='bottom-right', 
-                        type='positive', 
-                        group=False
+                        f"PWM updated {speeds[0]}, {speeds[1]}, {speeds[2]}",
+                        position='bottom-right', type='positive', group=False
                     )
-                    
-                    # Update the powerboard with the latest values
-                    await run.io_bound(
-                        globals.powerboardDict[1].update_fan_speed, 
-                        row0_pwm, 
-                        row1_pwm, 
-                        row2_pwm
-                    )
+                    await run.io_bound(pb_obj.update_fan_speed, *speeds)
             except Exception as e:
                 logger.error(f"Error updating fan speed: {e}")
                 ui.notify("Fan speed update failed", position='bottom-right', type='negative', group=False)
@@ -585,43 +610,33 @@ class FanControlService:
                 self.update_pwm_semaphore.release()
 
     async def request_update_auxiliary_fan_speed(self, slider_list: List):
-        """Request auxiliary fan speed update with UI queue protection for second powerboard."""
-        # Skip if we're updating sliders programmatically to prevent feedback loops
+        """Request auxiliary fan speed update for wall 4 using its current PB/header assignment."""
         if self.updating_sliders_programmatically:
             return
-            
+
         import globals
-        if 2 not in globals.powerboardDict:
+        wall = self.fan_walls.get(4)
+        if not wall or wall.powerboard_id is None or wall.header_index is None:
             return
-        
-        # Get the current auxiliary slider value right when semaphore becomes available
-        def get_current_aux_value():
-            return self.get_auxiliary_slider_value(slider_list)
-            
+        pb_obj = self._pb_for_location(wall.powerboard_id)
+        if pb_obj is None:
+            return
+
         acquired = self.update_aux_pwm_semaphore.acquire(blocking=False)
         if acquired:
             try:
-                pb = globals.powerboardDict[2]
-                await run.io_bound(pb.semaphore.acquire)
-                pb.semaphore.release()  # Wait for semaphore before updating
-                
-                # Get the latest auxiliary value right here when semaphore is available
-                aux_pwm = get_current_aux_value()
-                
+                await run.io_bound(pb_obj.semaphore.acquire)
+                pb_obj.semaphore.release()
+
+                aux_pwm = self.get_auxiliary_slider_value(slider_list)
+                speeds = list(pb_obj.get_running_fan_pwm())
+                speeds[wall.header_index] = aux_pwm
+
                 ui.notify(
                     f"Auxiliary PWM updated {aux_pwm}",
-                    position='bottom-right', 
-                    type='positive', 
-                    group=False
+                    position='bottom-right', type='positive', group=False
                 )
-                
-                # Update the powerboard with the latest value
-                await run.io_bound(
-                    pb.update_fan_speed, 
-                    aux_pwm, 
-                    aux_pwm, 
-                    aux_pwm
-                )
+                await run.io_bound(pb_obj.update_fan_speed, *speeds)
             except Exception as e:
                 logger.error(f"Error updating auxiliary fan speed: {e}")
                 ui.notify("Auxiliary fan speed update failed", position='bottom-right', type='negative', group=False)
@@ -659,76 +674,91 @@ class FanControlService:
             pb2.set_running_fan_pwm(aux, aux, aux)
         ui.notify("PWM set.", position='bottom-right', type='positive', group=False)
 
-    async def dialog_handler_discard(self, slider_list: List, 
+    async def dialog_handler_discard(self, slider_list: List,
                                    update_fan_speed_callback: Callable,
                                    update_aux_fan_speed_callback: Callable):
-        """Handle discarding fan speed changes for both powerboards."""
+        """Handle discarding fan speed changes, restoring saved values from each wall's assigned PB."""
         import globals
-        
-        # Reset powerboard 1 values
-        if 1 in globals.powerboardDict:
-            previous_pwm = globals.powerboardDict[1].get_saved_fan_pwm()
-            if len(slider_list) > 2:
-                self.set_slider_value_without_callback(slider_list[0], previous_pwm[0])
-                self.set_slider_value_without_callback(slider_list[1], previous_pwm[1])
-                self.set_slider_value_without_callback(slider_list[2], previous_pwm[2])
-                
-                await update_fan_speed_callback()
-                globals.powerboardDict[1].set_running_fan_pwm(previous_pwm[0], previous_pwm[1], previous_pwm[2])
-        
-        # Reset powerboard 2 values if it exists
-        if 2 in globals.powerboardDict and len(slider_list) > 3:
-            previous_aux_pwm = globals.powerboardDict[2].get_saved_fan_pwm()[2]  # Get saved auxiliary speed
-            self.set_slider_value_without_callback(slider_list[3], previous_aux_pwm)
-            
-            # Also update the running PWM on powerboard 2
+
+        # Reset main fan walls 1/2/3
+        for wall_id, slider_idx in ((1, 0), (2, 1), (3, 2)):
+            wall = self.fan_walls.get(wall_id)
+            if not wall or wall.powerboard_id is None or wall.header_index is None:
+                continue
+            pb_obj = self._pb_for_location(wall.powerboard_id)
+            if pb_obj is None:
+                continue
+            if slider_idx >= len(slider_list) or slider_list[slider_idx] is None:
+                continue
+            saved = pb_obj.get_saved_fan_pwm()
+            self.set_slider_value_without_callback(slider_list[slider_idx], saved[wall.header_index])
+
+        await update_fan_speed_callback()
+
+        # Reset aux wall 4
+        wall4 = self.fan_walls.get(4)
+        pb4 = self._pb_for_location(wall4.powerboard_id) if (wall4 and wall4.powerboard_id is not None) else None
+        if (pb4 and wall4.header_index is not None
+                and len(slider_list) > 3 and slider_list[3] is not None):
+            saved4 = pb4.get_saved_fan_pwm()
+            self.set_slider_value_without_callback(slider_list[3], saved4[wall4.header_index])
             await update_aux_fan_speed_callback()
-            globals.powerboardDict[2].set_running_fan_pwm(previous_aux_pwm, previous_aux_pwm, previous_aux_pwm)
-        
+
+        # Restore running PWM on each PB to its saved values
+        for pb_id, pb in globals.powerboardDict.items():
+            saved = pb.get_saved_fan_pwm()
+            pb.set_running_fan_pwm(*saved)
+
         ui.notify(
             "Fan speeds reset to saved values",
-            position='bottom-right', 
-            type='positive', 
-            group=False
+            position='bottom-right', type='positive', group=False
         )
 
     def check_for_changes(self, slider_list: List) -> bool:
         """Check if current slider values differ from saved powerboard values."""
         import globals
-        changes_detected = False
-        
-        # Check powerboard 1 for changes
-        if 1 in globals.powerboardDict:
-            pb1 = globals.powerboardDict[1]
-            current_values = self.get_current_slider_values(slider_list)
-            saved_values = pb1.get_saved_fan_pwm()
-            if current_values != saved_values:
-                changes_detected = True
-        
-        # Check powerboard 2 for changes if it exists
-        if 2 in globals.powerboardDict and len(slider_list) > 3:
-            pb2 = globals.powerboardDict[2]
-            saved_aux = pb2.get_saved_fan_pwm()[2]  # Get saved auxiliary speed
-            current_aux = self.get_auxiliary_slider_value(slider_list)
-            if saved_aux != current_aux:
-                changes_detected = True
-                
-        return changes_detected
+
+        for wall_id, slider_idx in ((1, 0), (2, 1), (3, 2)):
+            wall = self.fan_walls.get(wall_id)
+            if not wall or wall.powerboard_id is None or wall.header_index is None:
+                continue
+            pb_obj = self._pb_for_location(wall.powerboard_id)
+            if pb_obj is None:
+                continue
+            if slider_idx >= len(slider_list) or slider_list[slider_idx] is None:
+                continue
+            saved = pb_obj.get_saved_fan_pwm()
+            if slider_list[slider_idx].value != saved[wall.header_index]:
+                return True
+
+        wall4 = self.fan_walls.get(4)
+        pb4 = self._pb_for_location(wall4.powerboard_id) if (wall4 and wall4.powerboard_id is not None) else None
+        if (pb4 and wall4.header_index is not None
+                and len(slider_list) > 3 and slider_list[3] is not None):
+            saved4 = pb4.get_saved_fan_pwm()
+            if slider_list[3].value != saved4[wall4.header_index]:
+                return True
+
+        return False
 
     def get_saved_pwm_values(self) -> tuple:
-        """Get saved PWM values from powerboards."""
+        """Get saved PWM values from each wall's assigned powerboard/header."""
         import globals
-        
-        pb1_values = (0, 0, 0)
-        pb2_value = 0
-        
-        if 1 in globals.powerboardDict:
-            pb1_values = globals.powerboardDict[1].get_saved_fan_pwm()
-            
-        if 2 in globals.powerboardDict:
-            pb2_value = globals.powerboardDict[2].get_saved_fan_pwm()[2]
-            
-        return pb1_values, pb2_value
+
+        wall_saved = [0, 0, 0]
+        for wall_id in [1, 2, 3]:
+            wall = self.fan_walls.get(wall_id)
+            pb_obj = self._pb_for_location(wall.powerboard_id) if wall else None
+            if pb_obj and wall.header_index is not None:
+                wall_saved[wall_id - 1] = pb_obj.get_saved_fan_pwm()[wall.header_index]
+
+        aux_saved = 0
+        wall4 = self.fan_walls.get(4)
+        pb4 = self._pb_for_location(wall4.powerboard_id) if wall4 else None
+        if pb4 and wall4.header_index is not None:
+            aux_saved = pb4.get_saved_fan_pwm()[wall4.header_index]
+
+        return tuple(wall_saved), aux_saved
 
     def get_fan_profile_options(self) -> List[str]:
         """Get available fan profile options."""

--- a/foundry_state.py
+++ b/foundry_state.py
@@ -156,11 +156,16 @@ class SmartCtlInterface:
             return []
 
     @classmethod
-    def get_smart_data(cls, device_id: str, debug) -> Optional[Drive]:
-        """Get S.M.A.R.T. data for a specific device."""
+    def get_smart_data(cls, device_id: str, debug, allow_wakeup: bool = False) -> Optional[Drive]:
+        """Get S.M.A.R.T. data for a specific device.
+
+        allow_wakeup: if True, omits -n standby so the drive is spun up if needed.
+        Use this on first encounter so a drive in standby at startup is still registered.
+        """
         try:
             device_path = device_id.split(' ')[0]
-            json_output, returncode = cls.execute_command(f"-n standby --xall --json --device auto {device_path}")
+            standby_flag = "" if allow_wakeup else "-n standby "
+            json_output, returncode = cls.execute_command(f"{standby_flag}--xall --json --device auto {device_path}")
 
             # Exit code 2 means the drive is in standby/sleep — do not wake it.
             if returncode == 2:
@@ -318,8 +323,11 @@ class DriveManager:
 
         for device_id in drive_ids:
             device_path = device_id.split(' ')[0]
+            # Wake the drive on first encounter so it isn't silently skipped if
+            # it happens to be in standby at startup. Subsequent scans respect standby.
+            is_first_encounter = device_path not in self._device_path_to_hash
             try:
-                drive = SmartCtlInterface.get_smart_data(device_id, self._debug)
+                drive = SmartCtlInterface.get_smart_data(device_id, self._debug, allow_wakeup=is_first_encounter)
                 if drive:
                     drives[drive.hash] = drive
                     self._device_path_to_hash[device_path] = drive.hash
@@ -469,7 +477,7 @@ class Chassis:
     """Manages chassis layout and backplane configuration."""
 
     DEFAULT_CONFIG_FILE = "config/layout_config.json"
-    MAX_BACKPLANES = 12
+    MAX_BACKPLANES = 16
 
     def __init__(self, config_file: Optional[str] = None):
         self.config_file = config_file or self.DEFAULT_CONFIG_FILE
@@ -481,7 +489,6 @@ class Chassis:
         # Preferences
         self.chassis_orientation = False  # False for normal, True for inverted
         self.units = "C"  # Temperature units: "C" for Celsius, "F" for Fahrenheit
-        self.pb_swap = False # Powerboard swap preference
 
         if config_file:
             self._load_config()
@@ -512,7 +519,6 @@ class Chassis:
             else:
                 self.chassis_orientation = bool(orientation_value)
             self.units = options.get("units", "C")
-            self.pb_swap = options.get("pb_swap", False)
 
             # Ensure we have the right number of backplane slots
             while len(backplanes_data) < self.MAX_BACKPLANES:
@@ -578,15 +584,6 @@ class Chassis:
     def get_units(self) -> str:
         """Get temperature units."""
         return self.units
-
-    def set_pb_swap(self, value: bool) -> None:
-        """Set powerboard swap option."""
-        self.pb_swap = value
-        self.save_config()
-
-    def get_pb_swap(self) -> bool:
-        """Get powerboard swap option."""
-        return self.pb_swap
 
     def chassis_is_inverted(self) -> bool:
         """Get chassis orientation setting. Returns True if inverted, False if normal."""
@@ -684,8 +681,7 @@ class Chassis:
                         "show_sn": self.show_sn,
                         "hide_multi_curve_dialog": self.hide_multi_curve_dialog,
                         "chassis_orientation": self.chassis_orientation,
-                        "units": self.units,
-                        "pb_swap": self.pb_swap
+                        "units": self.units
                     }
             }
 

--- a/globals.py
+++ b/globals.py
@@ -32,18 +32,8 @@ def initPowerboard():
     for onePort in ports:
         if "Arduino Leonardo" in onePort.description:
             pb = Powerboard(onePort.device)
-            if layoutState and layoutState.get_pb_swap():
-                # If swap is enabled, assign powerboards inversely
-                if (pb.location == 1):
-                    powerboardDict[2] = pb
-                if (pb.location == 2):
-                    powerboardDict[1] = pb
-            else:
-                # Normal assignment
-                if (pb.location == 1):
-                    powerboardDict[1] = pb
-                if (pb.location == 2):
-                    powerboardDict[2] = pb
+            if pb.location in (1, 2):
+                powerboardDict[pb.location] = pb
 
     if len(powerboardDict) == 0:
         logger.warning("Powerboard not found")

--- a/pages/overview_page.py
+++ b/pages/overview_page.py
@@ -60,6 +60,10 @@ class DriveButton(ui.button):
         self.temp_label.set_visibility(True)
         self.temp_label.style('color: white')
         self.temp_label.bind_text_from(self.assigned_drive, 'temp', lambda temp: globals.format_temperature(temp))
+        if hasattr(self, 'remove_btn'):
+            self.remove_btn.set_visibility(True)
+        if hasattr(self, 'remove_menu_item'):
+            self.remove_menu_item.set_visibility(True)
 
     async def clear_drive(self):
         """Remove the assigned drive from this button."""
@@ -69,6 +73,10 @@ class DriveButton(ui.button):
         self.model_label.set_visibility(True)
         self.temp_label.set_visibility(False)
         self.sn_label.set_visibility(False)
+        if hasattr(self, 'remove_btn'):
+            self.remove_btn.set_visibility(False)
+        if hasattr(self, 'remove_menu_item'):
+            self.remove_menu_item.set_visibility(False)
         if self.on_click_handler:
             await self.on_click_handler(self)
 
@@ -167,45 +175,85 @@ class FanRowButtons(ui.element):
                 self.row_Of_Buttons.extend([b1, b2, b3])
 
 class RPMCard(ui.element):
-    """Button for fan row controls."""
+    """Displays RPM for the fan wall assigned to this grid position."""
 
     def __init__(self, index, grid_position: str) -> None:
         super().__init__('div')
+        wall_id = index + 1  # position 0 → wall 1, 1 → wall 2, 2 → wall 3
+        rpm_attrs = ['row1_rpm', 'row2_rpm', 'row3_rpm']
 
         with self.classes('px-1 p-1 flex content-center justify-center items-center w-full border-solid border-white rounded-md border-2 bg-neutral-900').style(f'grid-area: {grid_position};'):
-            if 1 in globals.powerboardDict:
-                match index:
-                    case 0:
-                        self.RPMLabel = ui.label().bind_text_from(globals.powerboardDict[1], 'row1_rpm', lambda rpm: f'{rpm} RPM')
-                    case 1:
-                        self.RPMLabel = ui.label().bind_text_from(globals.powerboardDict[1], 'row2_rpm', lambda rpm: f'{rpm} RPM')
-                    case 2:
-                        self.RPMLabel = ui.label().bind_text_from(globals.powerboardDict[1], 'row3_rpm', lambda rpm: f'{rpm} RPM')
+            wall = globals.fan_control_service.fan_walls.get(wall_id) if globals.fan_control_service else None
+            pb = next((p for p in globals.powerboardDict.values() if p.location == wall.powerboard_id), None) if wall and wall.powerboard_id is not None else None
+            if pb and wall.header_index is not None:
+                attr = rpm_attrs[wall.header_index]
+                self.RPMLabel = ui.label().bind_text_from(pb, attr, lambda rpm: f'{rpm} RPM')
             else:
                 ui.label('N/A').classes('text-gray-500 italic')
 
+
 class WattageCard(ui.element):
-    """Card to show wattage info from powerboard."""
+    """Displays wattage for the fan wall assigned to this grid position."""
+
+    # Physical wattage section per header index (board-level, not remappable per header)
+    _WATT_ATTRS = ['watt_sec_1_2', 'watt_sec_3_4', 'watt_sec_1_2', 'watt_sec_3_4']
 
     def __init__(self, index, grid_position: str) -> None:
         super().__init__('div')
+        wall_id = index + 1  # position 0 → wall 1, 1 → wall 2, 2 → wall 3, 3 → wall 4
+
         with self.classes('px-1 p-1 flex content-center justify-center items-center w-full border-solid border-white rounded-md border-2 bg-neutral-900').style(f'grid-area: {grid_position};'):
-            match index:
-                case 0:
-                    if 1 in globals.powerboardDict:
-                        self.watt_label = ui.label().bind_text_from(globals.powerboardDict[1], 'watt_sec_1_2', lambda wattage: f'Row 1: {wattage} watts')
-                    else:
-                        self.watt_label = ui.label('N/A').classes('text-gray-500 italic')
-                case 1:
-                    if 1 in globals.powerboardDict:
-                        self.watt_label = ui.label().bind_text_from(globals.powerboardDict[1], 'watt_sec_3_4', lambda wattage: f'Row 2: {wattage} watts')
-                    else:
-                        self.watt_label = ui.label('N/A').classes('text-gray-500 italic')
-                case 2:
-                    if 2 in globals.powerboardDict:
-                        self.watt_label = ui.label().bind_text_from(globals.powerboardDict[2], 'watt_sec_1_2', lambda wattage: f'Row 3: {wattage} watts')
-                    else:
-                        self.watt_label = ui.label('N/A').classes('text-gray-500 italic')
+            wall = globals.fan_control_service.fan_walls.get(wall_id) if globals.fan_control_service else None
+
+            # Priority 1: explicit wattage source configured independently of fan control
+            if wall and wall.watt_powerboard_id is not None and wall.watt_attr is not None:
+                pb = next((p for p in globals.powerboardDict.values() if p.location == wall.watt_powerboard_id), None)
+                watt_attr = wall.watt_attr
+            else:
+                # Priority 2: derive from fan wall assignment
+                pb = next((p for p in globals.powerboardDict.values() if p.location == wall.powerboard_id), None) if wall and wall.powerboard_id is not None else None
+                # Priority 3: fall back to pb1
+                if pb is None:
+                    pb = next((p for p in globals.powerboardDict.values() if p.location == 1), None)
+                watt_attr = self._WATT_ATTRS[min(wall.header_index, len(self._WATT_ATTRS) - 1)] if wall and wall.header_index is not None else self._WATT_ATTRS[min(index, len(self._WATT_ATTRS) - 1)]
+
+            if pb:
+                row_label = wall.watt_label if (wall and wall.watt_label) else f'Row {index + 1}'
+                self.watt_label = ui.label().bind_text_from(
+                    pb, watt_attr, lambda w, lbl=row_label: f'{lbl}: {w} watts'
+                )
+            else:
+                self.watt_label = ui.label('N/A').classes('text-gray-500 italic')
+
+
+class AuxFanCard(ui.element):
+    """Compact status card for auxiliary/unassigned fan walls shown in the bottom bar."""
+
+    _RPM_ATTRS = ['row1_rpm', 'row2_rpm', 'row3_rpm']
+
+    def __init__(self, wall_id: int) -> None:
+        super().__init__('div')
+        self.selected = False
+        wall = globals.fan_control_service.fan_walls.get(wall_id) if globals.fan_control_service else None
+        pb = next(
+            (p for p in globals.powerboardDict.values() if p.location == wall.powerboard_id),
+            None
+        ) if wall and wall.powerboard_id is not None else None
+
+        with self.classes(
+            'flex flex-col items-center justify-center px-3 py-2 border-solid border-white '
+            'rounded-md border-2 bg-neutral-900 cursor-pointer min-w-[110px] gap-0.5'
+        ):
+            if wall:
+                ui.label(wall.name).classes('text-xs font-medium text-center leading-tight')
+                if pb and wall.header_index is not None:
+                    attr = self._RPM_ATTRS[wall.header_index]
+                    ui.label().bind_text_from(pb, attr, lambda rpm: f'{rpm} RPM').classes('text-xs text-gray-400')
+                else:
+                    ui.label('Unassigned').classes('text-xs text-gray-500 italic')
+                ui.label().bind_text_from(wall, 'current_speed', lambda s: f'{int(s)}%').classes('text-sm font-bold')
+            else:
+                ui.label(f'Zone {wall_id}').classes('text-xs text-gray-500 italic')
 
 
 class StdPlaceHolderCard(ui.element):
@@ -219,6 +267,9 @@ class StdPlaceHolderCard(ui.element):
 
         if globals.layoutState.get_product() == "Hako-Core":
             if (index % 3 == 1): # 2nd column
+                self.tabsRight = False
+        elif globals.layoutState.get_product() == "Hako-Core DAS":
+            if (index % 4 in {1, 3}): # 2nd and 4th columns
                 self.tabsRight = False
         elif globals.layoutState.get_product() == "Hako-Core Mini":
             if (index % 2 == 1): # 2nd column
@@ -241,6 +292,9 @@ class SmlPlaceHolderCard(ui.element):
 
         if globals.layoutState.get_product() == "Hako-Core":
             if (index % 3 == 1): # 2nd column
+                self.tabsRight = False
+        elif globals.layoutState.get_product() == "Hako-Core DAS":
+            if (index % 4 in {1, 3}): # 2nd and 4th columns
                 self.tabsRight = False
         elif globals.layoutState.get_product() == "Hako-Core Mini":
             if (index % 2 == 1): # 2nd column
@@ -360,6 +414,38 @@ class ChassisLayoutManager:
                     "watt_positions": ["watt1", "watt2", "watt3"]
                 }
             },
+            "Hako-Core DAS": {
+                # 3 fan walls, 4 drive columns (cols 1+3 share orientation, cols 2+4 share orientation)
+                # Grid uses 23 columns: fan(1) + col(5) + fan(1) + col(5) + col(5) + fan(1) + col(5)
+                "normal": {
+                    "grid_template_areas": """
+                        "rpm1 watt1 watt1 watt1 watt1 watt1 rpm2 watt2 watt2 watt2 watt2 watt2 watt3 watt3 watt3 watt3 watt3 rpm3 watt4 watt4 watt4 watt4 watt4"
+                        "fan1 bp1 bp1 bp1 bp1 bp1 fan2 bp2 bp2 bp2 bp2 bp2 bp3 bp3 bp3 bp3 bp3 fan3 bp4 bp4 bp4 bp4 bp4"
+                        "fan1 bp5 bp5 bp5 bp5 bp5 fan2 bp6 bp6 bp6 bp6 bp6 bp7 bp7 bp7 bp7 bp7 fan3 bp8 bp8 bp8 bp8 bp8"
+                        "fan1 bp9 bp9 bp9 bp9 bp9 fan2 bp10 bp10 bp10 bp10 bp10 bp11 bp11 bp11 bp11 bp11 fan3 bp12 bp12 bp12 bp12 bp12"
+                        "fan1 sml1 sml1 sml1 sml1 sml1 fan2 sml2 sml2 sml2 sml2 sml2 sml3 sml3 sml3 sml3 sml3 fan3 sml4 sml4 sml4 sml4 sml4"
+                    """,
+                    "fan_positions": ["fan1", "fan2", "fan3"],
+                    "backplane_positions": ["bp1", "bp2", "bp3", "bp4", "bp5", "bp6", "bp7", "bp8", "bp9", "bp10", "bp11", "bp12"],
+                    "small_positions": ["sml1", "sml2", "sml3", "sml4"],
+                    "rpm_positions": ["rpm1", "rpm2", "rpm3"],
+                    "watt_positions": ["watt1", "watt2", "watt3", "watt4"]
+                },
+                "inverted": {
+                    "grid_template_areas": """
+                        "watt4 watt4 watt4 watt4 watt4 rpm3 watt3 watt3 watt3 watt3 watt3 watt2 watt2 watt2 watt2 watt2 rpm2 watt1 watt1 watt1 watt1 watt1 rpm1"
+                        "sml4 sml4 sml4 sml4 sml4 fan3 sml3 sml3 sml3 sml3 sml3 sml2 sml2 sml2 sml2 sml2 fan2 sml1 sml1 sml1 sml1 sml1 fan1"
+                        "bp12 bp12 bp12 bp12 bp12 fan3 bp11 bp11 bp11 bp11 bp11 bp10 bp10 bp10 bp10 bp10 fan2 bp9 bp9 bp9 bp9 bp9 fan1"
+                        "bp8 bp8 bp8 bp8 bp8 fan3 bp7 bp7 bp7 bp7 bp7 bp6 bp6 bp6 bp6 bp6 fan2 bp5 bp5 bp5 bp5 bp5 fan1"
+                        "bp4 bp4 bp4 bp4 bp4 fan3 bp3 bp3 bp3 bp3 bp3 bp2 bp2 bp2 bp2 bp2 fan2 bp1 bp1 bp1 bp1 bp1 fan1"
+                    """,
+                    "fan_positions": ["fan1", "fan2", "fan3"],
+                    "backplane_positions": ["bp1", "bp2", "bp3", "bp4", "bp5", "bp6", "bp7", "bp8", "bp9", "bp10", "bp11", "bp12"],
+                    "small_positions": ["sml1", "sml2", "sml3", "sml4"],
+                    "rpm_positions": ["rpm1", "rpm2", "rpm3"],
+                    "watt_positions": ["watt1", "watt2", "watt3", "watt4"]
+                }
+            },
             "Hako-Core Mini": {
                 "normal": {
                     "grid_template_areas": """
@@ -460,6 +546,8 @@ class SystemOverview:
         chassis = globals.layoutState.get_product()
         if chassis == "Hako-Core":
             return i in {0, 1, 3, 4, 6, 7, 9, 10}
+        if chassis == "Hako-Core DAS":
+            return i in {0, 1, 2, 4, 5, 6, 8, 9, 10}
         if chassis == "Hako-Core Mini":
             return i in {0, 1, 2, 3, 4, 5, 6, 7}
         if chassis == "HF-L1":
@@ -472,6 +560,8 @@ class SystemOverview:
         chassis = globals.layoutState.get_product()
         if chassis == "Hako-Core":
             return index in {0,1, 3,4, 6,7, 9,10}
+        if chassis == "Hako-Core DAS":
+            return index in {0,1,2, 4,5,6, 8,9,10}
         if chassis == "Hako-Core Mini":
             return index in {0,1, 2,3, 4,5}
         if chassis == "HF-L1":
@@ -611,267 +701,78 @@ class SystemOverview:
                     ui.label('No powerboards detected.').classes('text-gray-500 italic')
                 return
 
-            # Get available fan profiles
             profile_options = self.fan_control_service.get_fan_profile_options()
 
-            if 1 in globals.powerboardDict:  # Display fan speeds
-                # Get current fan wall states
-                wall_1 = self.fan_control_service.fan_walls.get(1)
-                wall_2 = self.fan_control_service.fan_walls.get(2)
-                wall_3 = self.fan_control_service.fan_walls.get(3)
+            # wall_id → slider_list index
+            wall_slider_map = {1: 0, 2: 1, 3: 2, 4: 3, 5: 4, 6: 5}
+            first_visible = True
 
-                # Fan Wall 1
-                with ui.row().classes('w-full items-center justify-between px-5 mt-5'):
-                    ui.label('Fan Wall 1').tooltip('Hidden fan header hidden under first powerboard.')
-                    manual_checkbox_1 = ui.checkbox('Manual', value=wall_1.manual).classes('text-sm')
+            for wall_id, slider_idx in wall_slider_map.items():
+                wall = self.fan_control_service.fan_walls.get(wall_id)
+                if not wall:
+                    continue
+                # Only show walls whose assigned powerboard is connected
+                if wall.powerboard_id not in globals.powerboardDict:
+                    continue
 
-                with ui.element('div').classes('px-5 pt-4 w-full'):
-                    self.slider_list[0] = ui.slider(
-                        min=20, max=100
-                    ).props('label-always')
-                    self.slider_list[0].bind_value(self.fan_control_service.fan_walls[1], 'current_speed')
-                    self.slider_list[0].set_enabled(wall_1.manual)  # Enabled based on manual state
+                if not first_visible:
+                    ui.separator()
+                first_visible = False
 
-                # Profile selection for Fan Wall 1 - hide when manual mode is enabled
-                profile_container_1 = ui.element('div').classes('px-5 pb-2 w-full')
-                with profile_container_1:
-                    profile_select_1 = ui.select(
+                # Header row: wall name + assignment subtitle + manual checkbox
+                header_label = wall.name
+                if wall.powerboard_id is not None and wall.header_index is not None:
+                    assignment_sub = f'PB{wall.powerboard_id} · Row {wall.header_index + 1}'
+                else:
+                    assignment_sub = 'Unassigned'
+
+                with ui.row().classes('w-full items-center justify-between px-5 mt-3'):
+                    with ui.column().classes('gap-0'):
+                        ui.label(header_label).classes('font-medium')
+                        ui.label(assignment_sub).classes('text-xs text-gray-500')
+                    manual_checkbox = ui.checkbox('Manual', value=wall.manual).classes('text-sm')
+
+                with ui.element('div').classes('px-5 pt-3 w-full'):
+                    self.slider_list[slider_idx] = ui.slider(min=20, max=100).props('label-always')
+                    self.slider_list[slider_idx].bind_value(wall, 'current_speed')
+                    self.slider_list[slider_idx].set_enabled(wall.manual)
+
+                profile_container = ui.element('div').classes('px-5 pb-2 w-full')
+                with profile_container:
+                    profile_select = ui.select(
                         options=profile_options,
                         label='Fan Profile',
-                        value=wall_1.assigned_profile if wall_1 and wall_1.assigned_profile in profile_options else profile_options[0]
+                        value=wall.assigned_profile if wall.assigned_profile in profile_options else (profile_options[0] if profile_options else None)
                     ).classes('w-full')
+                    profile_select.set_enabled(not wall.manual)
 
-                    profile_select_1.set_enabled(not (wall_1.manual if wall_1 else True))  # Enabled based on manual state
+                if wall.manual:
+                    profile_container.set_visibility(False)
 
-                # Hide/show profile container based on manual state
-                if wall_1 and wall_1.manual:
-                    profile_container_1.set_visibility(False)
+                if wall.assigned_profile and wall.assigned_profile != 'None' and not wall.manual:
+                    self.display_profile_sensors(wall.assigned_profile, 'px-5 pb-2 w-full')
 
-                # Display selected temperature sensors and values for Fan Wall 1
-                if wall_1 and wall_1.assigned_profile and wall_1.assigned_profile != 'None' and not wall_1.manual:
-                    self.display_profile_sensors(wall_1.assigned_profile, 'px-5 pb-2 w-full')
-
-                # Connect checkbox to slider/profile for Fan Wall 1
-                def toggle_fan_wall_1(e):
-                    self.slider_list[0].set_enabled(e.value)
-                    profile_select_1.set_enabled(not e.value)
-                    profile_container_1.set_visibility(not e.value)  # Hide when manual, show when profile mode
-
-                    # Update fan wall service
-                    self.fan_control_service.set_manual_mode(1, e.value)
-
-                    # When manual is unchecked, assign the first available fan profile
-                    if not e.value and profile_options:
-                        first_profile = profile_options[0]
-                        profile_select_1.set_value(first_profile)
-                        self.fan_control_service.assign_profile_to_wall(1, first_profile)
-
-                    # Refresh drawer to update sensor displays
-                    self.setup_fan_drawer()
-
-                manual_checkbox_1.on_value_change(toggle_fan_wall_1)
-
-                # Handle profile selection for Fan Wall 1
-                def on_profile_select_1(e):
-                    if not manual_checkbox_1.value:
-                        self.fan_control_service.assign_profile_to_wall(1, e.value)
-                        # Refresh drawer to update sensor displays
+                def make_toggle(wid, sidx, psel, pcont):
+                    def toggle(e):
+                        self.slider_list[sidx].set_enabled(e.value)
+                        psel.set_enabled(not e.value)
+                        pcont.set_visibility(not e.value)
+                        self.fan_control_service.set_manual_mode(wid, e.value)
+                        if not e.value and profile_options:
+                            psel.set_value(profile_options[0])
+                            self.fan_control_service.assign_profile_to_wall(wid, profile_options[0])
                         self.setup_fan_drawer()
+                    return toggle
 
-                profile_select_1.on_value_change(on_profile_select_1)
+                def make_profile_select(wid, mcb):
+                    def on_select(e):
+                        if not mcb.value:
+                            self.fan_control_service.assign_profile_to_wall(wid, e.value)
+                            self.setup_fan_drawer()
+                    return on_select
 
-                ui.separator()
-
-                # Fan Wall 2
-                with ui.row().classes('w-full items-center justify-between px-5 mb-2'):
-                    ui.label('Fan Wall 2').tooltip('Hidden fan header hidden under first powerboard.')
-                    manual_checkbox_2 = ui.checkbox('Manual', value=wall_2.manual if wall_2 else True).classes('text-sm')
-
-                with ui.element('div').classes('px-5 pt-1 w-full'):
-                    self.slider_list[1] = ui.slider(
-                        min=20, max=100,
-                    ).props('label-always')
-                    self.slider_list[1].bind_value(self.fan_control_service.fan_walls[2], 'current_speed')
-                    self.slider_list[1].set_enabled(wall_2.manual if wall_2 else True)  # Enabled based on manual state
-
-                # Profile selection for Fan Wall 2 - hide when manual mode is enabled
-                profile_container_2 = ui.element('div').classes('px-5 pb-2 w-full')
-                with profile_container_2:
-                    profile_select_2 = ui.select(
-                        options=profile_options,
-                        label='Fan Profile',
-                        value=wall_2.assigned_profile if wall_2 and wall_2.assigned_profile in profile_options else profile_options[0]
-                    ).classes('w-full')
-                    profile_select_2.set_enabled(not (wall_2.manual if wall_2 else True))  # Enabled based on manual state
-
-                # Hide/show profile container based on manual state
-                if wall_2 and wall_2.manual:
-                    profile_container_2.set_visibility(False)
-
-                # Display selected temperature sensors and values for Fan Wall 2
-                if wall_2 and wall_2.assigned_profile and wall_2.assigned_profile != 'None' and not wall_2.manual:
-                    self.display_profile_sensors(wall_2.assigned_profile, 'px-5 pb-2 w-full')
-
-                # Connect checkbox to slider/profile for Fan Wall 2
-                def toggle_fan_wall_2(e):
-                    self.slider_list[1].set_enabled(e.value)
-                    profile_select_2.set_enabled(not e.value)
-                    profile_container_2.set_visibility(not e.value)  # Hide when manual, show when profile mode
-
-                    # Update fan wall service
-                    self.fan_control_service.set_manual_mode(2, e.value)
-
-                    # When manual is unchecked, assign the first available fan profile
-                    if not e.value and profile_options:
-                        first_profile = profile_options[0]
-                        profile_select_2.set_value(first_profile)
-                        self.fan_control_service.assign_profile_to_wall(2, first_profile)
-
-                    # Refresh drawer to update sensor displays
-                    self.setup_fan_drawer()
-
-                manual_checkbox_2.on_value_change(toggle_fan_wall_2)
-
-                # Handle profile selection for Fan Wall 2
-                def on_profile_select_2(e):
-                    if not manual_checkbox_2.value:
-                        self.fan_control_service.assign_profile_to_wall(2, e.value)
-                        # Refresh drawer to update sensor displays
-                        self.setup_fan_drawer()
-
-                profile_select_2.on_value_change(on_profile_select_2)
-
-                ui.separator()
-
-                # Fan Wall 3
-                with ui.row().classes('w-full items-center justify-between px-5 mb-2'):
-                    ui.label('Fan Wall 3').tooltip('Exposed fan headers on the first powerboard.')
-                    manual_checkbox_3 = ui.checkbox('Manual', value=wall_3.manual if wall_3 else True).classes('text-sm')
-
-                with ui.element('div').classes('px-5 pt-1 w-full'):
-                    self.slider_list[2] = ui.slider(
-                        min=20, max=100
-                    ).props('label-always')
-                    self.slider_list[2].bind_value(self.fan_control_service.fan_walls[3], 'current_speed')
-                    self.slider_list[2].set_enabled(wall_3.manual if wall_3 else True)  # Enabled based on manual state
-
-                # Profile selection for Fan Wall 3 - hide when manual mode is enabled
-                profile_container_3 = ui.element('div').classes('px-5 pb-2 w-full')
-                with profile_container_3:
-                    profile_select_3 = ui.select(
-                        options=profile_options,
-                        label='Fan Profile',
-                        value=wall_3.assigned_profile if wall_3 and wall_3.assigned_profile in profile_options else profile_options[0]
-                    ).classes('w-full')
-                    profile_select_3.set_enabled(not (wall_3.manual if wall_3 else True))  # Enabled based on manual state
-
-                # Hide/show profile container based on manual state
-                if wall_3 and wall_3.manual:
-                    profile_container_3.set_visibility(False)
-
-                # Display selected temperature sensors and values for Fan Wall 3
-                if wall_3 and wall_3.assigned_profile and wall_3.assigned_profile != 'None' and not wall_3.manual:
-                    self.display_profile_sensors(wall_3.assigned_profile, 'px-5 pb-2 w-full')
-
-                # Connect checkbox to slider/profile for Fan Wall 3
-                def toggle_fan_wall_3(e):
-                    self.slider_list[2].set_enabled(e.value)
-                    profile_select_3.set_enabled(not e.value)
-                    profile_container_3.set_visibility(not e.value)  # Hide when manual, show when profile mode
-
-                    # Update fan wall service
-                    self.fan_control_service.set_manual_mode(3, e.value)
-
-                    # When manual is unchecked, assign the first available fan profile
-                    if not e.value and profile_options:
-                        first_profile = profile_options[0]
-                        profile_select_3.set_value(first_profile)
-                        self.fan_control_service.assign_profile_to_wall(3, first_profile)
-
-                    # Refresh drawer to update sensor displays
-                    self.setup_fan_drawer()
-
-                manual_checkbox_3.on_value_change(toggle_fan_wall_3)
-
-                # Handle profile selection for Fan Wall 3
-                def on_profile_select_3(e):
-                    if not manual_checkbox_3.value:
-                        self.fan_control_service.assign_profile_to_wall(3, e.value)
-                        # Refresh drawer to update sensor displays
-                        self.setup_fan_drawer()
-
-                profile_select_3.on_value_change(on_profile_select_3)
-
-                ui.separator()
-
-
-            if 2 in globals.powerboardDict:  # Display auxiliary fan control
-                pb: Powerboard = globals.powerboardDict[2]
-                # Get current saved auxiliary fan speed from powerboard 2
-                aux_pwm_tuple = pb.get_saved_fan_pwm()
-                aux_pwm = aux_pwm_tuple[2]  # Use row 3 as the auxiliary speed
-
-                # Get auxiliary fan wall state
-                wall_aux = self.fan_control_service.fan_walls.get(4)
-
-                # Auxiliary Fans
-                with ui.row().classes('w-full items-center justify-between px-5 mb-2'):
-                    ui.label('Auxiliary Fans').tooltip('Fan headers on the second powerboard.')
-                    manual_checkbox_aux = ui.checkbox('Manual', value=wall_aux.manual if wall_aux else True).classes('text-sm')
-
-                with ui.element('div').classes('px-5 pt-1 w-full'):
-                    self.slider_list[3] = ui.slider(
-                        min=20, max=100
-                    ).props('label-always')
-                    self.slider_list[3].bind_value(self.fan_control_service.fan_walls[4], 'current_speed')
-                    self.slider_list[3].set_enabled(wall_aux.manual if wall_aux else True)  # Enabled based on manual state
-
-                # Profile selection for Auxiliary Fans - hide when manual mode is enabled
-                profile_container_aux = ui.element('div').classes('px-5 pb-2 w-full')
-                with profile_container_aux:
-                    profile_select_aux = ui.select(
-                        options=profile_options,
-                        label='Fan Profile',
-                        value=wall_aux.assigned_profile if wall_aux and wall_aux.assigned_profile in profile_options else profile_options[0]
-                    ).classes('w-full')
-                    profile_select_aux.set_enabled(not (wall_aux.manual if wall_aux else True))  # Enabled based on manual state
-
-                # Hide/show profile container based on manual state
-                if wall_aux and wall_aux.manual:
-                    profile_container_aux.set_visibility(False)
-
-                # Display selected temperature sensors and values for Auxiliary Fans
-                if wall_aux and wall_aux.assigned_profile and wall_aux.assigned_profile != 'None' and not wall_aux.manual:
-                    self.display_profile_sensors(wall_aux.assigned_profile, 'px-5 pb-2 w-full')
-
-                # Connect checkbox to slider/profile for Auxiliary Fans
-                def toggle_auxiliary_fans(e):
-                    self.slider_list[3].set_enabled(e.value)
-                    profile_select_aux.set_enabled(not e.value)
-                    profile_container_aux.set_visibility(not e.value)  # Hide when manual, show when profile mode
-
-                    # Update auxiliary fan wall service
-                    self.fan_control_service.set_manual_mode(4, e.value)
-
-                    # When manual is unchecked, assign the first available fan profile
-                    if not e.value and profile_options:
-                        first_profile = profile_options[0]
-                        profile_select_aux.set_value(first_profile)
-                        self.fan_control_service.assign_profile_to_wall(4, first_profile)
-
-                    # Refresh drawer to update sensor displays
-                    self.setup_fan_drawer()
-
-                manual_checkbox_aux.on_value_change(toggle_auxiliary_fans)
-
-                # Handle profile selection for Auxiliary Fans
-                def on_profile_select_aux(e):
-                    if not manual_checkbox_aux.value:
-                        self.fan_control_service.assign_profile_to_wall(4, e.value)
-                        # Refresh drawer to update sensor displays
-                        self.setup_fan_drawer()
-
-                profile_select_aux.on_value_change(on_profile_select_aux)
+                manual_checkbox.on_value_change(make_toggle(wall_id, slider_idx, profile_select, profile_container))
+                profile_select.on_value_change(make_profile_select(wall_id, manual_checkbox))
 
                 ui.separator()
 
@@ -963,6 +864,26 @@ class SystemOverview:
                     )
                 ).classes('w-full')
 
+    def _attach_drive_button_controls(self, button):
+        """Add hover remove button and right-click context menu to a drive button."""
+        button.classes(add='relative')
+        has_drive = button.assigned_drive is not None
+        with button:
+            button.remove_btn = ui.button(
+                icon='close',
+                on_click=lambda b=button: b.clear_drive()
+            ).props('flat round dense size=xs color=grey-5').classes(
+                'absolute top-0 right-0 z-10 opacity-30 hover:opacity-100'
+            ).tooltip('Remove drive')
+            button.remove_btn.set_visibility(has_drive)
+
+            with ui.context_menu():
+                button.remove_menu_item = ui.menu_item(
+                    'Remove Disk',
+                    on_click=lambda b=button: b.clear_drive()
+                )
+                button.remove_menu_item.set_visibility(has_drive)
+
     def setup_backplane_buttons(self, card, backplane: Backplane, index):
         """Set up buttons for different backplane types (flip parent container in inverted mode)."""
         card.clear()
@@ -978,6 +899,8 @@ class SystemOverview:
             chassis = globals.layoutState.get_product()
             if chassis == "Hako-Core":
                 return i in {0, 1, 2, 3, 4, 6, 7, 9, 10}
+            if chassis == "Hako-Core DAS":
+                return i in {0, 1, 2, 4, 5, 6, 8, 9, 10}
             if chassis == "Hako-Core Mini":
                 return i in {0, 1, 2, 3, 4, 5}
             return False
@@ -1025,6 +948,7 @@ class SystemOverview:
                             button.classes('drive-button')
                             button.on_click_handler = self.select_drive
                             button.on('click', lambda b=button: self.select_drive(b))
+                            self._attach_drive_button_controls(button)
                             card.buttons.append(button.classes('truncate'))
                     ui.element('div').classes(f'extension-patch patch-top-arm-bottom{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
@@ -1040,6 +964,7 @@ class SystemOverview:
                             button.classes('drive-button')
                             button.on_click_handler = self.select_drive
                             button.on('click', lambda b=button: self.select_drive(b))
+                            self._attach_drive_button_controls(button)
                             card.buttons.append(button.classes('truncate'))
                     with ui.element('col2').classes('col-span-1 h-full'):
                         for i in range(6, 12):
@@ -1047,6 +972,7 @@ class SystemOverview:
                             button.classes('drive-button')
                             button.on_click_handler = self.select_drive
                             button.on('click', lambda b=button: self.select_drive(b))
+                            self._attach_drive_button_controls(button)
                             card.buttons.append(button.classes('truncate'))
                     ui.element('div').classes(f'extension-patch patch-top-arm-bottom{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
@@ -1067,6 +993,7 @@ class SystemOverview:
                                 button.props('no-wrap')
                             else:
                                 button.style('height: 28%;')
+                            self._attach_drive_button_controls(button)
                             card.buttons.append(button)
                     ui.element('div').classes(f'extension-patch patch-top-arm-bottom{cage}')
                     ui.element('div').classes(f'extension-patch patch-mid-arm-top{cage}')
@@ -1155,6 +1082,8 @@ class SystemOverview:
                 card_width = '50dvw'
             elif chassis_type == "HF-L1":
                 card_width = '35dvw'
+            elif chassis_type == "Hako-Core DAS":
+                card_width = '90dvw'
             else:
                 card_width = '70dvw'
             # Set grid template rows based on orientation (all chassis share the same 5-row structure)
@@ -1163,17 +1092,32 @@ class SystemOverview:
                 f'height: 98.9dvh; width: {card_width}; min-width: 800px; min-height: 800px; '
                 f'display: grid; grid-template-areas: {grid_template_areas}; '
                 f'grid-template-rows: {grid_rows}; '
-                f'grid-template-columns: repeat(24, 1fr);'
+                f'grid-template-columns: repeat({"23" if chassis_type == "Hako-Core DAS" else "24"}, 1fr);'
             ) as grid_container:
 
-                # RPM, wattage, fans (unchanged)
-                for i, position in enumerate(layout_config["rpm_positions"]):
-                    RPMCard(i, position)
+                def wall_assigned(wall_id: int) -> bool:
+                    if not globals.fan_control_service:
+                        return False
+                    wall = globals.fan_control_service.fan_walls.get(wall_id)
+                    return wall is not None and wall.powerboard_id is not None
+
+                def wall_assigned(wall_id: int) -> bool:
+                    if not globals.fan_control_service:
+                        return False
+                    wall = globals.fan_control_service.fan_walls.get(wall_id)
+                    return wall is not None and wall.powerboard_id is not None
+
+                # Wattage always renders — physical powerboard sections are always present
                 for i, position in enumerate(layout_config["watt_positions"]):
                     self.wattage_card_list.append(WattageCard(i, position))
+                # RPM and fan buttons only render if the wall has a powerboard assigned
+                for i, position in enumerate(layout_config["rpm_positions"]):
+                    if wall_assigned(i + 1):
+                        RPMCard(i, position)
                 for i, position in enumerate(layout_config["fan_positions"]):
-                    fan_row = FanRowButtons(self.select_fans, position)
-                    self.fan_buttons_list.extend(fan_row.row_Of_Buttons)
+                    if wall_assigned(i + 1):
+                        fan_row = FanRowButtons(self.select_fans, position)
+                        self.fan_buttons_list.extend(fan_row.row_Of_Buttons)
 
                 # Backplanes
                 if not globals.layoutState.is_empty():
@@ -1223,8 +1167,11 @@ class SystemOverview:
             with ui.row().classes('w-full justify-center gap-4'):
                 def select_hako_core():
                     chassis_dialog.close()
-                    # Force UI update after closing dialog
                     self.create_chassis_layout(main_content, "Hako-Core")
+
+                def select_hako_core_das():
+                    chassis_dialog.close()
+                    self.create_chassis_layout(main_content, "Hako-Core DAS")
 
                 def select_hako_core_mini():
                     chassis_dialog.close()
@@ -1237,6 +1184,11 @@ class SystemOverview:
                 ui.button(
                     'Hako-Core',
                     on_click=select_hako_core
+                ).classes('border-solid border-2 border-[#ffdd00] px-8 py-4').props('flat color="white"')
+
+                ui.button(
+                    'Hako-Core DAS',
+                    on_click=select_hako_core_das
                 ).classes('border-solid border-2 border-[#ffdd00] px-8 py-4').props('flat color="white"')
 
                 ui.button(
@@ -1263,8 +1215,22 @@ class SystemOverview:
                     if current_chassis is None:
                         # Show chassis selection dialog
                         self.show_chassis_selection_dialog(main_content)
-                    elif current_chassis in ["Hako-Core", "Hako-Core Mini", "HF-L1"]:
+                    elif current_chassis in ["Hako-Core", "Hako-Core DAS", "Hako-Core Mini", "HF-L1"]:
                         self.create_chassis_layout(main_content, current_chassis)
+
+            # Auxiliary / unassigned fan zones bar — below chassis grid, in normal page flow
+            if globals.fan_control_service:
+                aux_wall_ids = [
+                    wid for wid in [4, 5, 6]
+                    if wid in globals.fan_control_service.fan_walls
+                    and globals.fan_control_service.fan_walls[wid].powerboard_id is not None
+                ]
+                if aux_wall_ids:
+                    with ui.row().classes('gap-2 p-2 justify-center w-full'):
+                        for wid in aux_wall_ids:
+                            card = AuxFanCard(wid)
+                            self.fan_buttons_list.append(card)
+                            card.on('click', lambda c=card: self.select_fans(c))
 
             # Create drawers and dialogs
             self.right_drawer = ui.right_drawer(value=False, fixed=True).style().props(

--- a/pages/overview_page.py
+++ b/pages/overview_page.py
@@ -1,8 +1,7 @@
 from typing import Optional
-from nicegui import app, ui, run
+from nicegui import app, ui
 from authentication import require_auth
-from powerboard import Powerboard
-from foundry_state import Chassis, Backplane, Drive
+from foundry_state import Backplane, Drive
 import xxhash
 import page_layout
 import globals
@@ -48,12 +47,12 @@ class DriveButton(ui.button):
         drive_hash = xxhash.xxh3_64(sn).intdigest()
         self.assigned_drive = globals.drivesList[drive_hash]
 
-        if globals.layoutState.show_model == True:
+        if globals.layoutState.show_model:
             self.model_label.style('color: white')
             self.model_label.set_text(self.assigned_drive.model)
         else:
             self.model_label.set_visibility(False)
-        if globals.layoutState.show_sn == True:
+        if globals.layoutState.show_sn:
             self.sn_label.set_visibility(True)
             self.sn_label.style('color: white')
             self.sn_label.set_text(self.assigned_drive.serial_num)
@@ -98,9 +97,9 @@ class HDDButton(DriveButton):
                     'overflow-hidden whitespace-nowrap text-ellipsis flex-1 min-w-0'
                 ).style('display: block;')
 
-                if globals.layoutState.show_model == False and self.assigned_drive != None:
+                if not globals.layoutState.show_model and self.assigned_drive is not None:
                     self.model_label.set_visibility(False)
-                if globals.layoutState.show_sn == False or self.assigned_drive is None:
+                if not globals.layoutState.show_sn or self.assigned_drive is None:
                     self.sn_label.set_visibility(False)
 
 class SmlSSDButton(DriveButton):
@@ -120,9 +119,9 @@ class SmlSSDButton(DriveButton):
                 'overflow-hidden whitespace-nowrap text-ellipsis flex-1 min-w-0'
             ).style('display: block; direction: rtl;')
 
-            if globals.layoutState.show_model == False and self.assigned_drive != None:
+            if not globals.layoutState.show_model and self.assigned_drive is not None:
                 self.model_label.set_visibility(False)
-            if globals.layoutState.show_sn == False or self.assigned_drive is None:
+            if not globals.layoutState.show_sn or self.assigned_drive is None:
                 self.sn_label.set_visibility(False)
 
 class StdSSDButton(DriveButton):
@@ -142,9 +141,9 @@ class StdSSDButton(DriveButton):
                 'overflow-hidden whitespace-nowrap text-ellipsis flex-1 min-w-0'
             ).style('display: block; direction: rtl;')
 
-            if globals.layoutState.show_model == False and self.assigned_drive != None:
+            if not globals.layoutState.show_model and self.assigned_drive is not None:
                 self.model_label.set_visibility(False)
-            if globals.layoutState.show_sn == False or self.assigned_drive is None:
+            if not globals.layoutState.show_sn or self.assigned_drive is None:
                 self.sn_label.set_visibility(False)
 
 class FansRowButton(ui.button):
@@ -675,7 +674,7 @@ class SystemOverview:
                                 current_temp = globals.fan_profile_service.get_sensor_temperature(sensor_name) if globals.fan_profile_service else None
                                 temp_display = globals.format_temperature(current_temp) if current_temp is not None else "N/A"
                                 label.set_text(temp_display)
-                            except Exception as e:
+                            except Exception:
                                 label.set_text("Error")
 
                         # Initial update
@@ -1093,13 +1092,7 @@ class SystemOverview:
                 f'display: grid; grid-template-areas: {grid_template_areas}; '
                 f'grid-template-rows: {grid_rows}; '
                 f'grid-template-columns: repeat({"23" if chassis_type == "Hako-Core DAS" else "24"}, 1fr);'
-            ) as grid_container:
-
-                def wall_assigned(wall_id: int) -> bool:
-                    if not globals.fan_control_service:
-                        return False
-                    wall = globals.fan_control_service.fan_walls.get(wall_id)
-                    return wall is not None and wall.powerboard_id is not None
+            ):
 
                 def wall_assigned(wall_id: int) -> bool:
                     if not globals.fan_control_service:

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -1,4 +1,4 @@
-from nicegui import ui
+from nicegui import ui, run
 from authentication import require_auth
 import globals
 import page_layout
@@ -71,57 +71,41 @@ def settingsPage():
                 ui.button('No', on_click=on_no).classes('border-solid border-2 border-[#ffdd00]').props('flat color="white"')
         dialog.open()
 
-    def get_pwm_values():
-        """Get current saved PWM values from powerboards."""
-        pwm_data = {}
-
-        # Get powerboard 1 PWM values
-        if 1 in globals.powerboardDict:
-            pb1_pwm = globals.powerboardDict[1].get_saved_fan_pwm()
-            pwm_data['pb1'] = {
-                'row1': pb1_pwm[0],
-                'row2': pb1_pwm[1],
-                'row3': pb1_pwm[2]
-            }
-
-        # Get powerboard 2 PWM values
-        if 2 in globals.powerboardDict:
-            pb2_pwm = globals.powerboardDict[2].get_saved_fan_pwm()
-            pwm_data['pb2'] = {
-                'aux': pb2_pwm[2]  # Use third value for auxiliary
-            }
-
-        return pwm_data
-
     def create_pwm_settings():
-        """Create PWM settings interface."""
-        pwm_data = get_pwm_values()
+        """Create PWM settings interface. Shows all 3 headers per connected powerboard;
+        headers without a fan wall assignment are displayed but disabled."""
+        if not globals.powerboardDict:
+            ui.label('No powerboards detected for PWM settings.').classes('text-gray-500 italic')
+            return
 
-        if not pwm_data:
-            return ui.label('No powerboards detected for PWM settings.').classes('text-gray-500 italic')
+        svc = globals.fan_control_service
 
-        # Store PWM input references
-        pwm_inputs = {}
+        # Build lookup: (pb_location, header_index) -> FanWall
+        wall_by_assignment: dict = {}
+        if svc and svc.fan_walls:
+            for wall in svc.fan_walls.values():
+                if wall.powerboard_id is not None and wall.header_index is not None:
+                    wall_by_assignment[(wall.powerboard_id, wall.header_index)] = wall
+
+        header_labels = {0: 'Row 1', 1: 'Row 2', 2: 'Row 3'}
+        # (pb_location, header_index) -> slider; keyed this way so apply can rebuild per-PB arrays
+        pwm_inputs: dict = {}
+        pb_objects: dict = {}  # pb_location -> pb_obj, for use in apply
 
         async def apply_pwm_settings():
-            """Apply the PWM settings using fan control service."""
+            """Write all slider values to each powerboard's EEPROM."""
             try:
-                # Get values from inputs
-                pb1_values = [0, 0, 0]
-                pb2_aux = 100
+                pb_speeds: dict = {}
+                for (pb_location, header_index), slider in pwm_inputs.items():
+                    pb_obj = pb_objects.get(pb_location)
+                    if pb_obj is None:
+                        continue
+                    if pb_location not in pb_speeds:
+                        pb_speeds[pb_location] = {'pb': pb_obj, 'speeds': list(pb_obj.get_saved_fan_pwm())}
+                    pb_speeds[pb_location]['speeds'][header_index] = int(slider.value)
 
-                if 'pb1' in pwm_data:
-                    pb1_values[0] = int(pwm_inputs['pb1_row1'].value)
-                    pb1_values[1] = int(pwm_inputs['pb1_row2'].value)
-                    pb1_values[2] = int(pwm_inputs['pb1_row3'].value)
-
-                if 'pb2' in pwm_data:
-                    pb2_aux = int(pwm_inputs['pb2_aux'].value)
-
-                # Use fan control service to set the speeds
-                await globals.fan_control_service.set_fan_speed(
-                    pb1_values[0], pb1_values[1], pb1_values[2], pb2_aux
-                )
+                for entry in pb_speeds.values():
+                    await run.io_bound(entry['pb'].set_fan_speed, *entry['speeds'])
 
                 ui.notify("PWM settings applied successfully!",
                          position='bottom-right', type='positive', group=False)
@@ -131,46 +115,37 @@ def settingsPage():
                          position='bottom-right', type='negative', group=False)
 
         with ui.column().classes('w-full gap-4'):
-            # Powerboard 1 settings
-            if 'pb1' in pwm_data:
+            for pb_id in sorted(globals.powerboardDict.keys()):
+                pb_obj = globals.powerboardDict[pb_id]
+                saved = pb_obj.get_saved_fan_pwm()
+                pb_objects[pb_obj.location] = pb_obj
+
                 with ui.card().classes('w-full'):
-                    ui.label('Powerboard 1 - Fan Rows').classes('text-lg font-semibold mb-2')
+                    ui.label(f'Powerboard {pb_obj.location}').classes('text-lg font-semibold mb-2')
                     with ui.grid(columns=3).classes('gap-4 w-full'):
-                        with ui.column().classes('items-center gap-2'):
-                            ui.label('Row 1 PWM')
-                            pwm_inputs['pb1_row1'] = ui.slider(
-                                min=0, max=100, step=1,
-                                value=int(pwm_data['pb1']['row1'])
-                            ).classes('w-32')
-                            ui.label().bind_text_from(pwm_inputs['pb1_row1'], 'value', lambda v: f'{int(v)}%')
+                        for header_index in range(3):
+                            wall = wall_by_assignment.get((pb_obj.location, header_index))
+                            assigned = wall is not None
 
-                        with ui.column().classes('items-center gap-2'):
-                            ui.label('Row 2 PWM')
-                            pwm_inputs['pb1_row2'] = ui.slider(
-                                min=0, max=100, step=1,
-                                value=int(pwm_data['pb1']['row2'])
-                            ).classes('w-32')
-                            ui.label().bind_text_from(pwm_inputs['pb1_row2'], 'value', lambda v: f'{int(v)}%')
+                            with ui.column().classes('items-center gap-2'):
+                                if assigned:
+                                    ui.label(wall.name)
+                                else:
+                                    ui.label(f'{header_labels[header_index]} - unassigned').classes('text-gray-500 italic text-sm')
 
-                        with ui.column().classes('items-center gap-2'):
-                            ui.label('Row 3 PWM')
-                            pwm_inputs['pb1_row3'] = ui.slider(
-                                min=0, max=100, step=1,
-                                value=int(pwm_data['pb1']['row3'])
-                            ).classes('w-32')
-                            ui.label().bind_text_from(pwm_inputs['pb1_row3'], 'value', lambda v: f'{int(v)}%')
+                                slider = ui.slider(
+                                    min=0, max=100, step=1,
+                                    value=int(saved[header_index])
+                                ).classes('w-32')
+                                if not assigned:
+                                    slider.props('disable')
+                                    slider.tooltip('No fan wall assigned to this header')
 
-            # Powerboard 2 settings (show only if exists)
-            if 'pb2' in pwm_data:
-                with ui.card().classes('w-full'):
-                    ui.label('Powerboard 2 - Auxiliary Fans').classes('text-lg font-semibold mb-2')
-                    with ui.column().classes('items-center gap-2 w-full'):
-                        ui.label('Auxiliary PWM')
-                        pwm_inputs['pb2_aux'] = ui.slider(
-                            min=0, max=100, step=1,
-                            value=int(pwm_data['pb2']['aux'])
-                        ).classes('w-64')
-                        ui.label().bind_text_from(pwm_inputs['pb2_aux'], 'value', lambda v: f'{int(v)}%')
+                                ui.label().bind_text_from(
+                                    slider, 'value', lambda v: f'{int(v)}%'
+                                ).classes('' if assigned else 'text-gray-500')
+
+                                pwm_inputs[(pb_obj.location, header_index)] = slider
 
             # Apply button
             with ui.row().classes('justify-center w-full mt-4'):
@@ -354,7 +329,7 @@ def settingsPage():
                 ui.separator().classes('mb-6')
 
                 # PWM Settings Section
-                with ui.column().classes('w-full') as pwm_container:
+                with ui.column().classes('w-full'):
                     ui.label('Default Fan Speed').classes('text-xl font-bold mb-4')
                     ui.label('These will be used when the system starts and persist between power cycles.').classes('text-sm text-gray-500 mb-2')
                     create_pwm_settings()

--- a/pages/settings_page.py
+++ b/pages/settings_page.py
@@ -5,7 +5,7 @@ import page_layout
 
 @require_auth
 def settingsPage():
-    """Settings page for chassis layout and powerboard information."""
+    """Settings page for chassis layout and fan configuration."""
 
     # Use a mutable object to store the flag so it can be accessed in nested functions
     state_flags = {'ignoring_change': False}
@@ -22,6 +22,7 @@ def settingsPage():
         """Change the chassis product and reset layout."""
         globals.layoutState.reset_chassis()
         globals.layoutState.set_product(new_product)
+        wattage_source_ui.refresh()
 
     def change_model_display(value):
         # If turning off model display, ensure SN display is on
@@ -31,28 +32,6 @@ def settingsPage():
             if ui_refs['sn_switch']:
                 ui_refs['sn_switch'].set_value(True)
         globals.layoutState.set_model_display(value)
-
-    def swap_powerboard_positions():
-        """Swap the positions of powerboard 1 and 2 in powerboardDict."""
-        pb1 = globals.powerboardDict.get(1)
-        pb2 = globals.powerboardDict.get(2)
-
-        if pb1 and pb2:
-            # Swap the Powerboard objects in the dictionary
-            globals.powerboardDict[1], globals.powerboardDict[2] = globals.powerboardDict[2], globals.powerboardDict[1]
-
-            ui.notify("Powerboard positions swapped!",
-                     position='bottom-right', type='positive', group=False)
-            # Refresh the powerboard information table
-            powerboard_container.clear()
-            with powerboard_container:
-                create_powerboard_table()
-        elif pb1 or pb2:
-            ui.notify("Only one powerboard detected, cannot swap.",
-                     position='bottom-right', type='warning', group=False)
-        else:
-            ui.notify("No powerboards detected, cannot swap.",
-                     position='bottom-right', type='warning', group=False)
 
     def change_sn_display(value):
         # If turning off SN display, ensure model display is on
@@ -91,56 +70,6 @@ def settingsPage():
                 ui.button('Yes', on_click=lambda: (change_product(new_product), dialog.close())).classes('border-solid border-2 border-[#ffdd00]').props('flat color="white"')
                 ui.button('No', on_click=on_no).classes('border-solid border-2 border-[#ffdd00]').props('flat color="white"')
         dialog.open()
-
-    def get_powerboard_info():
-        """Get powerboard information for table display."""
-        powerboard_data = []
-
-        for position in [1, 2]:
-            if position in globals.powerboardDict:
-                pb = globals.powerboardDict[position]
-                try:
-                    # Get connection port info
-                    port = getattr(pb, '_serial_instance', None)
-                    port_name = port.port if port and hasattr(port, 'port') else 'Unknown'
-
-                    powerboard_data.append({
-                        'port': port_name,
-                        'hardware_rev': pb.hardware_revision if hasattr(pb, 'hardware_revision') else 'Unknown',
-                        'firmware_ver': pb.firmware_version if hasattr(pb, 'firmware_version') else 'Unknown',
-                        'location': pb.location if hasattr(pb, 'location') else 'Unknown'
-                    })
-                except Exception as e:
-                    # Fallback for any errors accessing powerboard properties
-                    powerboard_data.append({
-                        'port': 'Error',
-                        'hardware_rev': 'Error',
-                        'firmware_ver': 'Error',
-                        'location': 'Error'
-                    })
-
-        return powerboard_data
-
-    def create_powerboard_table():
-        """Create and return powerboard information table."""
-        powerboard_data = get_powerboard_info()
-
-        if not powerboard_data:
-            return ui.label('No powerboards detected.').classes('text-gray-500 italic')
-
-        # Define table columns
-        columns = [
-            {'name': 'port', 'label': 'Serial Port', 'field': 'port', 'required': True, 'align': 'left'},
-            {'name': 'hardware_rev', 'label': 'Hardware Rev', 'field': 'hardware_rev', 'required': True, 'align': 'center'},
-            {'name': 'firmware_ver', 'label': 'Firmware Ver', 'field': 'firmware_ver', 'required': True, 'align': 'center'},
-            {'name': 'location', 'label': 'Location', 'field': 'location', 'required': True, 'align': 'center'}
-        ]
-
-        return ui.table(
-            columns=columns,
-            rows=powerboard_data,
-            row_key='location'
-        ).classes('w-full')
 
     def get_pwm_values():
         """Get current saved PWM values from powerboards."""
@@ -250,6 +179,108 @@ def settingsPage():
                     on_click=apply_pwm_settings
                 ).classes('border-solid border-2 border-[#ffdd00] text-white px-6 py-2').props('flat')
 
+    def create_fan_wall_assignments():
+        """Create fan wall assignment UI."""
+        if not globals.fan_control_service or not globals.fan_control_service.fan_walls:
+            return ui.label('No fan walls initialized.').classes('text-gray-500 italic')
+
+        svc = globals.fan_control_service
+        pb_options = {pb.location: f'Powerboard {pb.location}' for pb in sorted(globals.powerboardDict.values(), key=lambda p: p.location)}
+        header_options = {0: 'Row 1', 1: 'Row 2', 2: 'Row 3'}
+
+        with ui.grid(columns=3).classes('w-full gap-x-4 gap-y-2'):
+            # Column headers
+            ui.label('Fan Wall').classes('text-xs text-gray-400 uppercase tracking-wide font-semibold')
+            ui.label('Powerboard').classes('text-xs text-gray-400 uppercase tracking-wide font-semibold')
+            ui.label('Header').classes('text-xs text-gray-400 uppercase tracking-wide font-semibold')
+
+            for wall_id in sorted(svc.fan_walls.keys()):
+                wall = svc.fan_walls[wall_id]
+
+                ui.label(wall.name).classes('text-sm self-center')
+
+                pb_select = ui.select(
+                    options={None: 'Unassigned', **pb_options},
+                    value=wall.powerboard_id,
+                ).classes('w-full')
+
+                header_select = ui.select(
+                    options={None: 'Unassigned', **header_options},
+                    value=wall.header_index,
+                ).classes('w-full')
+
+                def on_change(_, wid=wall_id, pb_sel=pb_select, hdr_sel=header_select):
+                    success = svc.set_wall_assignment(wid, pb_sel.value, hdr_sel.value)
+                    if not success:
+                        # Revert selects to current (unchanged) values
+                        w = svc.fan_walls[wid]
+                        pb_sel.set_value(w.powerboard_id)
+                        hdr_sel.set_value(w.header_index)
+                        ui.notify(
+                            'That powerboard/header is already assigned to another fan wall.',
+                            position='bottom-right', type='warning', group=False
+                        )
+                    else:
+                        ui.notify(
+                            f'{svc.fan_walls[wid].name} assignment saved.',
+                            position='bottom-right', type='positive', group=False
+                        )
+
+                pb_select.on_value_change(on_change)
+                header_select.on_value_change(on_change)
+
+    @ui.refreshable
+    def wattage_source_ui():
+        create_wattage_source_assignments()
+
+    def create_wattage_source_assignments():
+        """Configure independent wattage source (pdb + connector) per wall display row."""
+        if not globals.fan_control_service or not globals.fan_control_service.fan_walls:
+            return ui.label('No fan walls initialized.').classes('text-gray-500 italic')
+
+        svc = globals.fan_control_service
+        pb_options = {pb.location: f'Powerboard {pb.location}' for pb in sorted(globals.powerboardDict.values(), key=lambda p: p.location)}
+        connector_options = {
+            'watt_sec_1_2': 'Section 1-2',
+            'watt_sec_3_4': 'Section 3-4',
+        }
+
+        _chassis_watt_rows = {'Hako-Core': 3, 'Hako-Core DAS': 4, 'Hako-Core Mini': 2, 'HF-L1': 1}
+        chassis = globals.layoutState.get_product()
+        watt_wall_ids = list(range(1, _chassis_watt_rows.get(chassis, 3) + 1))
+
+        with ui.grid(columns=3).classes('w-full gap-x-4 gap-y-2'):
+            ui.label('Row').classes('text-xs text-gray-400 uppercase tracking-wide font-semibold')
+            ui.label('Powerboard').classes('text-xs text-gray-400 uppercase tracking-wide font-semibold')
+            ui.label('Connector').classes('text-xs text-gray-400 uppercase tracking-wide font-semibold')
+
+            for wall_id in watt_wall_ids:
+                wall = svc.fan_walls.get(wall_id)
+                if not wall:
+                    continue
+
+                ui.label(f'Drive Row {wall_id}').classes('text-sm self-center')
+
+                pb_sel = ui.select(
+                    options={None: 'Auto', **pb_options},
+                    value=wall.watt_powerboard_id,
+                ).classes('w-full')
+
+                conn_sel = ui.select(
+                    options={None: 'Auto', **connector_options},
+                    value=wall.watt_attr,
+                ).classes('w-full')
+
+                def on_watt_change(_, wid=wall_id, pb_s=pb_sel, conn_s=conn_sel):
+                    svc.set_wall_wattage_source(wid, pb_s.value, conn_s.value)
+                    ui.notify(
+                        f'{svc.fan_walls[wid].name} wattage source saved.',
+                        position='bottom-right', type='positive', group=False
+                    )
+
+                pb_sel.on_value_change(on_watt_change)
+                conn_sel.on_value_change(on_watt_change)
+
     # Main settings UI
     with page_layout.frame('Settings'):
         with ui.element('div').classes('flex w-full').style('justify-content: safe center;'):
@@ -259,7 +290,7 @@ def settingsPage():
                 with ui.grid(columns=2).classes('gap-0 w-full').style('grid-auto-rows: 1fr;'):
                     ui.label('Chassis Layout:').classes('flex justify-start items-center')
                     product_select = ui.select(
-                        ['Hako-Core', 'Hako-Core Mini', 'HF-L1'],
+                        ['Hako-Core', 'Hako-Core DAS', 'Hako-Core Mini', 'HF-L1'],
                         value=globals.layoutState.get_product(),
                         on_change=handle_product_change
                     )
@@ -283,7 +314,7 @@ def settingsPage():
                     current_unit = globals.layoutState.get_units()
                     # Find the display name for the current value
                     current_display = next((k for k, v in unit_options.items() if v == current_unit), 'Celsius (C°)')
-                    
+
                     ui.select(
                         list(unit_options.keys()),
                         value=current_display,
@@ -322,23 +353,27 @@ def settingsPage():
 
                 ui.separator().classes('mb-6')
 
-                # Powerboard Information Section
-                with ui.column().classes('w-full') as powerboard_container:
-                    ui.label('Powerboard Information').classes('text-xl font-bold mb-4')
-                    create_powerboard_table()
-                if 2 in globals.powerboardDict:
-                    with ui.row().classes('w-full justify-center'):
-                        ui.label('Swap powerboard positions:').classes('flex justify-start items-center ')
-                        ui_refs['pb_swap_switch'] = ui.switch(value=globals.layoutState.get_pb_swap(), on_change=lambda e: (globals.layoutState.set_pb_swap(e.value), swap_powerboard_positions())).style('justify-content:end;')
-
-
-                ui.separator().classes('mb-6')
-
                 # PWM Settings Section
                 with ui.column().classes('w-full') as pwm_container:
                     ui.label('Default Fan Speed').classes('text-xl font-bold mb-4')
                     ui.label('These will be used when the system starts and persist between power cycles.').classes('text-sm text-gray-500 mb-2')
                     create_pwm_settings()
+
+                ui.separator().classes('mb-6')
+
+                # Fan Wall Assignments Section
+                with ui.column().classes('w-full'):
+                    ui.label('Fan Wall Assignments').classes('text-xl font-bold mb-2')
+                    ui.label('Assign each fan wall to a powerboard and header row. Each combination can only be used once.').classes('text-sm text-gray-500 mb-4')
+                    create_fan_wall_assignments()
+
+                ui.separator().classes('mb-6')
+
+                # Wattage Source Assignments Section
+                with ui.column().classes('w-full'):
+                    ui.label('Wattage Source Assignments').classes('text-xl font-bold mb-2')
+                    ui.label('Override which powerboard connector supplies power readings for each display row. Defaults to the fan wall assignment if not set.').classes('text-sm text-gray-500 mb-4')
+                    wattage_source_ui()
 
                 # Additional spacing
                 ui.space().classes('h-2')


### PR DESCRIPTION
Refactors fan wall control to be dynamically assigned rather than hardcoded to specific powerboards. Each fan wall can now be independently assigned to a powerboard and header row through the Settings page, with a separate wattage source assignment per display row. Adds support for the Hako-Core DAS chassis (4-row x 4-col). Removes the powerboard swap UI in favor of the new assignment system. Also improves the backplane removal workflow and extends the overview page to support auxiliary fan zones.